### PR TITLE
ATLAS-89: Specify use of .Net Core SDK 2.2.x to fix Validation tests on devops build pipeline.

### DIFF
--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -44,6 +44,11 @@ jobs:
   #Your build pipeline references an undefined variable named ‘Parameters.packagesDirectory’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .Net Core sdk 2.2.x'
+    inputs:
+      version: 2.2.x
+
   - task: DotNetCoreCLI@2
     inputs:
       command: 'restore'


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/3)
<!-- Reviewable:end -->
