### PR TITLE
chore: ATLAS-75: Adding resource group name to container

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -19,5 +19,6 @@ resource "azurerm_storage_account" "azure_storage" {
 resource "azurerm_storage_container" "search_matching_results_blob_container" {
   name                  = "matching-algorithm-results"
   storage_account_name  = azurerm_storage_account.azure_storage.name
+  resource_group_name   = azurerm_resource_group.atlas_resource_group.name
   container_access_type = "private"
 }


### PR DESCRIPTION
Adding the resource group name fixes this issue 
Terraform validate being run successfully 
Think the documentation I was looking at was slightly out of date but will make sure to run terraform validate from now on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/11)
<!-- Reviewable:end -->
