### PR TITLE
Created Haplotype tables for MatchPrediction

### DIFF
--- a/Atlas.MatchPrediction.Data/Context/MatchPredictionContext.cs
+++ b/Atlas.MatchPrediction.Data/Context/MatchPredictionContext.cs
@@ -13,12 +13,7 @@ namespace Atlas.MatchPrediction.Data.Context
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            foreach (var relationship in modelBuilder.Model.GetEntityTypes().SelectMany(e => e.GetForeignKeys()))
-            {
-                relationship.DeleteBehavior = DeleteBehavior.Restrict;
-            }
-
-            modelBuilder.Entity<HaplotypeFrequencySets>()
+            modelBuilder.Entity<HaplotypeFrequencySet>()
                 .HasIndex(d => new { d.Ethnicity, d.Registry })
                 .HasName("IX_RegistryAndEthnicity")
                 .IsUnique()
@@ -27,7 +22,7 @@ namespace Atlas.MatchPrediction.Data.Context
             base.OnModelCreating(modelBuilder);
         }
 
-        public DbSet<HaplotypeFrequencySets> HaplotypeFrequencySets { get; set; }
-        public DbSet<HaplotypeInfo> HaplotypeInfo { get; set; }
+        public DbSet<HaplotypeFrequencySet> HaplotypeFrequencySets { get; set; }
+        public DbSet<HaplotypeFrequency> HaplotypeFrequencies { get; set; }
     }
 }

--- a/Atlas.MatchPrediction.Data/Migrations/20200513132557_AddHaplotypeFrequencySetsAndHaplotypeInfoTables.Designer.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20200513132557_AddHaplotypeFrequencySetsAndHaplotypeInfoTables.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.MatchPrediction.Data.Migrations
 {
     [DbContext(typeof(MatchPredictionContext))]
-    [Migration("20200513113832_AddHaplotypeFrequencySetsAndHaplotypeInfoTables")]
+    [Migration("20200513132557_AddHaplotypeFrequencySetsAndHaplotypeInfoTables")]
     partial class AddHaplotypeFrequencySetsAndHaplotypeInfoTables
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -21,31 +21,9 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySets", b =>
+            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequency", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                    b.Property<bool>("Active");
-
-                    b.Property<string>("Ethnicity");
-
-                    b.Property<string>("Registry");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Ethnicity", "Registry")
-                        .IsUnique()
-                        .HasName("IX_RegistryAndEthnicity")
-                        .HasFilter("[Active] = 'True'");
-
-                    b.ToTable("HaplotypeFrequencySets");
-                });
-
-            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeInfo", b =>
-                {
-                    b.Property<int>("Id")
+                    b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
                         .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
@@ -72,15 +50,36 @@ namespace Atlas.MatchPrediction.Data.Migrations
 
                     b.HasIndex("Set_Id");
 
-                    b.ToTable("HaplotypeInfo");
+                    b.ToTable("HaplotypeFrequencies");
                 });
 
-            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeInfo", b =>
+            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySet", b =>
                 {
-                    b.HasOne("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySets", "SetId")
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<bool>("Active");
+
+                    b.Property<string>("Ethnicity");
+
+                    b.Property<string>("Registry");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Ethnicity", "Registry")
+                        .IsUnique()
+                        .HasName("IX_RegistryAndEthnicity")
+                        .HasFilter("[Active] = 'True'");
+
+                    b.ToTable("HaplotypeFrequencySets");
+                });
+
+            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequency", b =>
+                {
+                    b.HasOne("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySet", "SetId")
                         .WithMany()
-                        .HasForeignKey("Set_Id")
-                        .OnDelete(DeleteBehavior.Restrict);
+                        .HasForeignKey("Set_Id");
                 });
 #pragma warning restore 612, 618
         }

--- a/Atlas.MatchPrediction.Data/Migrations/20200513132557_AddHaplotypeFrequencySetsAndHaplotypeInfoTables.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20200513132557_AddHaplotypeFrequencySetsAndHaplotypeInfoTables.cs
@@ -23,10 +23,10 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "HaplotypeInfo",
+                name: "HaplotypeFrequencies",
                 columns: table => new
                 {
-                    Id = table.Column<int>(nullable: false)
+                    Id = table.Column<long>(nullable: false)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     Set_Id = table.Column<int>(nullable: true),
                     Frequency = table.Column<decimal>(nullable: false),
@@ -38,9 +38,9 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_HaplotypeInfo", x => x.Id);
+                    table.PrimaryKey("PK_HaplotypeFrequencies", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_HaplotypeInfo_HaplotypeFrequencySets_Set_Id",
+                        name: "FK_HaplotypeFrequencies_HaplotypeFrequencySets_Set_Id",
                         column: x => x.Set_Id,
                         principalTable: "HaplotypeFrequencySets",
                         principalColumn: "Id",
@@ -48,22 +48,22 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 });
 
             migrationBuilder.CreateIndex(
+                name: "IX_HaplotypeFrequencies_Set_Id",
+                table: "HaplotypeFrequencies",
+                column: "Set_Id");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_RegistryAndEthnicity",
                 table: "HaplotypeFrequencySets",
                 columns: new[] { "Ethnicity", "Registry" },
                 unique: true,
                 filter: "[Active] = 'True'");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_HaplotypeInfo_Set_Id",
-                table: "HaplotypeInfo",
-                column: "Set_Id");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "HaplotypeInfo");
+                name: "HaplotypeFrequencies");
 
             migrationBuilder.DropTable(
                 name: "HaplotypeFrequencySets");

--- a/Atlas.MatchPrediction.Data/Migrations/MatchPredictionContextModelSnapshot.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/MatchPredictionContextModelSnapshot.cs
@@ -19,31 +19,9 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySets", b =>
+            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequency", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                    b.Property<bool>("Active");
-
-                    b.Property<string>("Ethnicity");
-
-                    b.Property<string>("Registry");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Ethnicity", "Registry")
-                        .IsUnique()
-                        .HasName("IX_RegistryAndEthnicity")
-                        .HasFilter("[Active] = 'True'");
-
-                    b.ToTable("HaplotypeFrequencySets");
-                });
-
-            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeInfo", b =>
-                {
-                    b.Property<int>("Id")
+                    b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
                         .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
@@ -70,15 +48,36 @@ namespace Atlas.MatchPrediction.Data.Migrations
 
                     b.HasIndex("Set_Id");
 
-                    b.ToTable("HaplotypeInfo");
+                    b.ToTable("HaplotypeFrequencies");
                 });
 
-            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeInfo", b =>
+            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySet", b =>
                 {
-                    b.HasOne("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySets", "SetId")
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<bool>("Active");
+
+                    b.Property<string>("Ethnicity");
+
+                    b.Property<string>("Registry");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Ethnicity", "Registry")
+                        .IsUnique()
+                        .HasName("IX_RegistryAndEthnicity")
+                        .HasFilter("[Active] = 'True'");
+
+                    b.ToTable("HaplotypeFrequencySets");
+                });
+
+            modelBuilder.Entity("Atlas.MatchPrediction.Data.Models.HaplotypeFrequency", b =>
+                {
+                    b.HasOne("Atlas.MatchPrediction.Data.Models.HaplotypeFrequencySet", "SetId")
                         .WithMany()
-                        .HasForeignKey("Set_Id")
-                        .OnDelete(DeleteBehavior.Restrict);
+                        .HasForeignKey("Set_Id");
                 });
 #pragma warning restore 612, 618
         }

--- a/Atlas.MatchPrediction.Data/Models/HaplotypeFrequency.cs
+++ b/Atlas.MatchPrediction.Data/Models/HaplotypeFrequency.cs
@@ -3,11 +3,11 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Atlas.MatchPrediction.Data.Models
 {
-    public class HaplotypeInfo
+    public class HaplotypeFrequency
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         [ForeignKey("Set_Id")]
-        public HaplotypeFrequencySets SetId { get; set; }
+        public HaplotypeFrequencySet SetId { get; set; }
         public decimal Frequency { get; set; }
         [Required]
         public string A { get; set; }

--- a/Atlas.MatchPrediction.Data/Models/HaplotypeFrequencySet.cs
+++ b/Atlas.MatchPrediction.Data/Models/HaplotypeFrequencySet.cs
@@ -1,6 +1,6 @@
 ﻿namespace Atlas.MatchPrediction.Data.Models
 {
-    public class HaplotypeFrequencySets
+    public class HaplotypeFrequencySet
     {
         public int Id { get; set; }
         public string Registry { get; set; }


### PR DESCRIPTION
Structure:
After talking with Zabeen the structure I came up with was two separate tables seen below:

 haplotype
• A 
• B
• C
• DQB1
• DRB1
• Frequency
The example dataset from NMDP has this as a decimal to 16dp. We should store to at least this accuracy. 
• Set ID - each frequeny data set
An identifier for the uploaded frequency set, to distinguish different historic versions of the dataset. 

• haplotypeSet
• Registry
String. Consumer of ATLAS responsible for ensuring this matches the values used for donors. Nullable.
• Ethnicity
String. Consumer of ATLAS responsible for ensuring this matches the values used for donors. Nullable.
• Active Flag
Used to “soft delete” frequency sets
• ID - each frequeny data set
An identifier for the uploaded frequency set, to distinguish different historic versions of the dataset. 


For an active flag if it is true there can only be one -Registry -Ethnicity combination as there can only be one source of truth, where a flag is false there can be multiple -Registry -Ethnicity combinations as they are no longer the most up-to-date

Testing:
- Created tables locally and made sure all the constraints and connections where working correctly and the table was built correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/93)
<!-- Reviewable:end -->
