### PR TITLE
chore: ATLAS-231: Functions app cleanup

### DIFF
--- a/Atlas.DonorImport.Functions/Atlas.DonorImport.Functions.csproj
+++ b/Atlas.DonorImport.Functions/Atlas.DonorImport.Functions.csproj
@@ -9,8 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AzureExtensions.Swashbuckle" Version="3.1.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
   </ItemGroup>
 

--- a/Atlas.DonorImport.Functions/Functions/HealthCheckFunctions.cs
+++ b/Atlas.DonorImport.Functions/Functions/HealthCheckFunctions.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 
 namespace Atlas.DonorImport.Functions.Functions
 {
-    public class HealthCheck
+    public class HealthCheckFunctions
     {
-        [FunctionName("HealthCheck")]
-        public static OkObjectResult Check([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
+        [FunctionName(nameof(HealthCheck))]
+        public static OkObjectResult HealthCheck([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
         {
             const string responseMessage = "This HTTP triggered function executed successfully";
             return new OkObjectResult(responseMessage);

--- a/Atlas.DonorImport.Functions/Functions/SwaggerFunctions.cs
+++ b/Atlas.DonorImport.Functions/Functions/SwaggerFunctions.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http;
+using AzureFunctions.Extensions.Swashbuckle;
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace Atlas.DonorImport.Functions.Functions
+{
+    public static class SwaggerFunctions
+    {
+        [SwaggerIgnore]
+        [FunctionName(nameof(Swagger))]
+        public static HttpResponseMessage Swagger(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/json")]
+            HttpRequestMessage req,
+            [SwashBuckleClient] ISwashBuckleClient swashBuckleClient)
+        {
+            return swashBuckleClient.CreateSwaggerDocumentResponse(req);
+        }
+
+        [SwaggerIgnore]
+        [FunctionName(nameof(SwaggerUi))]
+        public static HttpResponseMessage SwaggerUi(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/ui")]
+            HttpRequestMessage req,
+            [SwashBuckleClient] ISwashBuckleClient swashBuckleClient)
+        {
+            return swashBuckleClient.CreateSwaggerUIResponse(req, "swagger/json");
+        }
+    }
+}

--- a/Atlas.DonorImport.Functions/SwaggerStartup.cs
+++ b/Atlas.DonorImport.Functions/SwaggerStartup.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using Atlas.DonorImport.Functions;
+using AzureFunctions.Extensions.Swashbuckle;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+
+[assembly: FunctionsStartup(typeof(SwashBuckleStartup))]
+namespace Atlas.DonorImport.Functions
+{
+    internal class SwashBuckleStartup : IWebJobsStartup
+    {
+        public void Configure(IWebJobsBuilder builder)
+        {
+            builder.AddSwashBuckle(Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/Atlas.Functions/Atlas.Functions.csproj
+++ b/Atlas.Functions/Atlas.Functions.csproj
@@ -7,6 +7,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="AzureExtensions.Swashbuckle" Version="3.1.6" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
         <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     </ItemGroup>

--- a/Atlas.Functions/Functions/HealthCheckFunctions.cs
+++ b/Atlas.Functions/Functions/HealthCheckFunctions.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 
-namespace Atlas.MatchPrediction.Functions.Functions
+namespace Atlas.Functions.Functions
 {
-    public class HealthCheck
+    public static class HealthCheckFunctions
     {
-        [FunctionName("HealthCheck")]
-        public static OkObjectResult Check([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
+        [FunctionName(nameof(HealthCheck))]
+        public static OkObjectResult HealthCheck([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
         {
             const string responseMessage = "This HTTP triggered function executed successfully";
             return new OkObjectResult(responseMessage);

--- a/Atlas.Functions/Functions/SearchFunctions.cs
+++ b/Atlas.Functions/Functions/SearchFunctions.cs
@@ -1,35 +1,31 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using Atlas.Common.Utils;
 using Atlas.MatchingAlgorithm.Client.Models.SearchRequests;
-using Atlas.MatchingAlgorithm.Common.Models;
 using Atlas.MatchingAlgorithm.Helpers;
 using Atlas.MatchingAlgorithm.Services.Search;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Newtonsoft.Json;
 
-namespace Atlas.MatchingAlgorithm.Functions.Functions
+namespace Atlas.Functions.Functions
 {
-    public class Search
+    public class SearchFunctions
     {
         private readonly ISearchDispatcher searchDispatcher;
-        private readonly ISearchRunner searchRunner;
 
-        public Search(ISearchDispatcher searchDispatcher, ISearchRunner searchRunner)
+        public SearchFunctions(ISearchDispatcher searchDispatcher)
         {
             this.searchDispatcher = searchDispatcher;
-            this.searchRunner = searchRunner;
         }
 
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
         [FunctionName(nameof(InitiateSearch))]
-        public async Task<IActionResult> InitiateSearch([HttpTrigger] HttpRequest request)
+        public async Task<IActionResult> InitiateSearch([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest request)
         {
             var searchRequest = JsonConvert.DeserializeObject<SearchRequest>(await new StreamReader(request.Body).ReadToEndAsync());
             try
@@ -41,18 +37,6 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
             {
                 return new BadRequestObjectResult(e.ToValidationErrorsModel());
             }
-        }
-
-        [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName(nameof(RunSearch))]
-        public async Task RunSearch(
-            [ServiceBusTrigger("%MessagingServiceBus:SearchRequestsQueue%", Connection = "MessagingServiceBus:ConnectionString")]
-            Message message)
-        {
-            var serialisedData = Encoding.UTF8.GetString(message.Body);
-            var request = JsonConvert.DeserializeObject<IdentifiedSearchRequest>(serialisedData);
-
-            await searchRunner.RunSearch(request);
         }
     }
 }

--- a/Atlas.Functions/Functions/SwaggerFunctions.cs
+++ b/Atlas.Functions/Functions/SwaggerFunctions.cs
@@ -4,12 +4,12 @@ using AzureFunctions.Extensions.Swashbuckle.Attribute;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 
-namespace Atlas.MatchPrediction.Functions.Functions
+namespace Atlas.Functions.Functions
 {
     public static class SwaggerFunctions
     {
         [SwaggerIgnore]
-        [FunctionName("Swagger")]
+        [FunctionName(nameof(Swagger))]
         public static HttpResponseMessage Swagger(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/json")]
             HttpRequestMessage req,
@@ -19,7 +19,7 @@ namespace Atlas.MatchPrediction.Functions.Functions
         }
 
         [SwaggerIgnore]
-        [FunctionName("SwaggerUi")]
+        [FunctionName(nameof(SwaggerUi))]
         public static HttpResponseMessage SwaggerUi(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/ui")]
             HttpRequestMessage req,

--- a/Atlas.Functions/SwaggerStartup.cs
+++ b/Atlas.Functions/SwaggerStartup.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using Atlas.Functions;
+using AzureFunctions.Extensions.Swashbuckle;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+
+[assembly: FunctionsStartup(typeof(SwashBuckleStartup))]
+namespace Atlas.Functions
+{
+    internal class SwashBuckleStartup : IWebJobsStartup
+    {
+        public void Configure(IWebJobsBuilder builder)
+        {
+            builder.AddSwashBuckle(Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/Atlas.MatchPrediction.Functions/Functions/HaplotypeFrequencySetFunctions.cs
+++ b/Atlas.MatchPrediction.Functions/Functions/HaplotypeFrequencySetFunctions.cs
@@ -1,17 +1,15 @@
-﻿using Atlas.Common.ApplicationInsights;
+﻿using System.IO;
+using System.Threading.Tasks;
 using Atlas.MatchPrediction.Services.HaplotypeFrequencies;
 using Microsoft.Azure.WebJobs;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Atlas.MatchPrediction.Functions.Functions
 {
-    public class HaplotypeFrequencySet
+    public class HaplotypeFrequencySetFunctions
     {
         private readonly IFrequencySetService frequencySetService;
 
-        public HaplotypeFrequencySet(IFrequencySetService frequencySetService)
+        public HaplotypeFrequencySetFunctions(IFrequencySetService frequencySetService)
         {
             this.frequencySetService = frequencySetService;
         }

--- a/Atlas.MatchPrediction.Functions/Functions/HealthCheckFunctions.cs
+++ b/Atlas.MatchPrediction.Functions/Functions/HealthCheckFunctions.cs
@@ -1,14 +1,14 @@
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 
-namespace Atlas.Functions.Functions
+namespace Atlas.MatchPrediction.Functions.Functions
 {
-    public static class HealthCheck
+    public class HealthCheckFunctions
     {
-        [FunctionName("HealthCheck")]
-        public static OkObjectResult Check([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
+        [FunctionName(nameof(HealthCheck))]
+        public static OkObjectResult HealthCheck([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
         {
             const string responseMessage = "This HTTP triggered function executed successfully";
             return new OkObjectResult(responseMessage);

--- a/Atlas.MatchPrediction.Functions/Functions/SwaggerFunctions.cs
+++ b/Atlas.MatchPrediction.Functions/Functions/SwaggerFunctions.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http;
+using AzureFunctions.Extensions.Swashbuckle;
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace Atlas.MatchPrediction.Functions.Functions
+{
+    public static class SwaggerFunctions
+    {
+        [SwaggerIgnore]
+        [FunctionName(nameof(Swagger))]
+        public static HttpResponseMessage Swagger(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/json")]
+            HttpRequestMessage req,
+            [SwashBuckleClient] ISwashBuckleClient swashBuckleClient)
+        {
+            return swashBuckleClient.CreateSwaggerDocumentResponse(req);
+        }
+
+        [SwaggerIgnore]
+        [FunctionName(nameof(SwaggerUi))]
+        public static HttpResponseMessage SwaggerUi(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/ui")]
+            HttpRequestMessage req,
+            [SwashBuckleClient] ISwashBuckleClient swashBuckleClient)
+        {
+            return swashBuckleClient.CreateSwaggerUIResponse(req, "swagger/json");
+        }
+    }
+}

--- a/Atlas.MatchPrediction.Functions/host.json
+++ b/Atlas.MatchPrediction.Functions/host.json
@@ -1,11 +1,11 @@
 {
-    "version": "2.0",
-    "logging": {
-        "applicationInsights": {
-            "samplingExcludedTypes": "Request",
-            "samplingSettings": {
-                "isEnabled": true
-            }
-        }
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingExcludedTypes": "Request",
+      "samplingSettings": {
+        "isEnabled": true
+      }
     }
+  }
 }

--- a/Atlas.MatchingAlgorithm.Api/SwaggerStartup.cs
+++ b/Atlas.MatchingAlgorithm.Api/SwaggerStartup.cs
@@ -9,9 +9,9 @@ namespace Atlas.MatchingAlgorithm.Api
     {
         public static IServiceCollection ConfigureSwaggerService(this IServiceCollection services)
         {
-            services.AddSwaggerGen(c =>
+            services.AddSwaggerGen(options =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+                options.SwaggerDoc("v1", new OpenApiInfo {Title = "My API", Version = "v1"});
             });
             return services;
         }

--- a/Atlas.MatchingAlgorithm.Functions.DonorManagement/Functions/CachingFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions.DonorManagement/Functions/CachingFunctions.cs
@@ -8,12 +8,12 @@ using Microsoft.Azure.WebJobs;
 
 namespace Atlas.MatchingAlgorithm.Functions.DonorManagement.Functions
 {
-    public class Caching
+    public class CachingFunctions
     {
         private readonly IAntigenCachingService antigenCachingService;
         private readonly IHlaMetadataCacheControl hlaMetadataCacheControl;
 
-        public Caching(
+        public CachingFunctions(
             IAntigenCachingService antigenCachingService,
             IHlaMetadataDictionaryFactory hlaMetadataDictionaryFactory,
             IActiveHlaVersionAccessor hlaVersionAccessor

--- a/Atlas.MatchingAlgorithm.Functions.DonorManagement/Functions/DonorManagementFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions.DonorManagement/Functions/DonorManagementFunctions.cs
@@ -8,28 +8,29 @@ using Atlas.Common.ServiceBus.Exceptions;
 using Atlas.Common.Utils;
 using Atlas.MatchingAlgorithm.Client.Models.Donors;
 using Atlas.MatchingAlgorithm.Exceptions;
-using Atlas.MatchingAlgorithm.Models;
 using Atlas.MatchingAlgorithm.Services.DonorManagement;
 using Microsoft.Azure.WebJobs;
 
 namespace Atlas.MatchingAlgorithm.Functions.DonorManagement.Functions
 {
-    public class DonorManagement
+    public class DonorManagementFunctions
     {
-        const string ErrorMessagePrefix = "Error when running the donor management function. ";
+        private const string ErrorMessagePrefix = "Error when running the donor management function. ";
 
         private readonly IDonorUpdateProcessor donorUpdateProcessor;
         private readonly ILogger logger;
 
-        public DonorManagement(IDonorUpdateProcessor donorUpdateProcessor, ILogger logger)
+        public DonorManagementFunctions(IDonorUpdateProcessor donorUpdateProcessor, ILogger logger)
         {
             this.donorUpdateProcessor = donorUpdateProcessor;
             this.logger = logger;
         }
 
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("ManageDonorByAvailability")]
-        public async Task Run([TimerTrigger("%MessagingServiceBus:DonorManagement:CronSchedule%")] TimerInfo myTimer)
+        [FunctionName(nameof(ManageDonorByAvailability))]
+        public async Task ManageDonorByAvailability(
+            [TimerTrigger("%MessagingServiceBus:DonorManagement:CronSchedule%")]
+            TimerInfo myTimer)
         {
             try
             {

--- a/Atlas.MatchingAlgorithm.Functions/Atlas.MatchingAlgorithm.Functions.csproj
+++ b/Atlas.MatchingAlgorithm.Functions/Atlas.MatchingAlgorithm.Functions.csproj
@@ -10,6 +10,7 @@
         <RootNamespace>Atlas.MatchingAlgorithm.Functions</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="AzureExtensions.Swashbuckle" Version="3.1.6" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />

--- a/Atlas.MatchingAlgorithm.Functions/Functions/CachingFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/CachingFunctions.cs
@@ -7,12 +7,12 @@ using Microsoft.Azure.WebJobs;
 
 namespace Atlas.MatchingAlgorithm.Functions.Functions
 {
-    public class Caching
+    public class CachingFunctions
     {
         private readonly IAntigenCachingService antigenCachingService;
         private readonly IHlaMetadataCacheControl hlaMetadataCacheControl;
 
-        public Caching(
+        public CachingFunctions(
             IAntigenCachingService antigenCachingService,
             IHlaMetadataCacheControl hlaMetadataCacheControl
         )

--- a/Atlas.MatchingAlgorithm.Functions/Functions/DataRefreshFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/DataRefreshFunctions.cs
@@ -4,15 +4,16 @@ using Atlas.Common.Utils;
 using Atlas.MatchingAlgorithm.Services.DataRefresh;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 
 namespace Atlas.MatchingAlgorithm.Functions.Functions
 {
-    public class DataRefresh
+    public class DataRefreshFunctions
     {
         private readonly IDataRefreshOrchestrator dataRefreshOrchestrator;
         private readonly IDataRefreshCleanupService dataRefreshCleanupService;
 
-        public DataRefresh(IDataRefreshOrchestrator dataRefreshOrchestrator, IDataRefreshCleanupService dataRefreshCleanupService)
+        public DataRefreshFunctions(IDataRefreshOrchestrator dataRefreshOrchestrator, IDataRefreshCleanupService dataRefreshCleanupService)
         {
             this.dataRefreshOrchestrator = dataRefreshOrchestrator;
             this.dataRefreshCleanupService = dataRefreshCleanupService;
@@ -22,8 +23,8 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
         /// Runs a full data refresh, regardless of whether the existing database is using the latest version of the hla database
         /// </summary>
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("ForceDataRefresh")]
-        public async Task ForceDataRefresh([HttpTrigger] HttpRequest httpRequest)
+        [FunctionName(nameof(ForceDataRefresh))]
+        public async Task ForceDataRefresh([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest httpRequest)
         {
             await dataRefreshOrchestrator.RefreshDataIfNecessary(shouldForceRefresh: true);
         }
@@ -32,8 +33,8 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
         /// Runs a full data refresh, if necessary
         /// </summary>
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("RunDataRefreshManual")]
-        public async Task RunDataRefreshManual([HttpTrigger] HttpRequest httpRequest)
+        [FunctionName(nameof(RunDataRefreshManual))]
+        public async Task RunDataRefreshManual([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest httpRequest)
         {
             await dataRefreshOrchestrator.RefreshDataIfNecessary();
         }
@@ -42,7 +43,7 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
         /// Runs a full data refresh, if necessary
         /// </summary>
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("RunDataRefresh")]
+        [FunctionName(nameof(RunDataRefresh))]
         public async Task RunDataRefresh([TimerTrigger("%DataRefresh:CronTab%")] TimerInfo timerInfo)
         {
             await dataRefreshOrchestrator.RefreshDataIfNecessary();
@@ -55,8 +56,8 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
         /// The only time this should be triggered is if the server running the data refresh was restarted while the job was in progress, causing it to skip tear-down.
         /// </summary>
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("RunDataRefreshCleanup")]
-        public async Task RunDataRefreshCleanup([HttpTrigger] HttpRequest httpRequest)
+        [FunctionName(nameof(RunDataRefreshCleanup))]
+        public async Task RunDataRefreshCleanup([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest httpRequest)
         {
             await dataRefreshCleanupService.RunDataRefreshCleanup();
         }
@@ -65,7 +66,7 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
         /// On start-up, checks for in-progress jobs - if any are present, implies teardown was not completed - so notifies the support team.
         /// </summary>
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("CheckIfCleanupNecessary")]
+        [FunctionName(nameof(CheckIfCleanupNecessary))]
         public async Task CheckIfCleanupNecessary([TimerTrigger("00 00 11 01 06 *", RunOnStartup = true)] TimerInfo timerInfo)
         {
             await dataRefreshCleanupService.SendCleanupRecommendation();

--- a/Atlas.MatchingAlgorithm.Functions/Functions/HlaMetadataDictionaryFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/HlaMetadataDictionaryFunctions.cs
@@ -5,23 +5,24 @@ using Atlas.HlaMetadataDictionary.ExternalInterface;
 using Atlas.MatchingAlgorithm.Services.ConfigurationProviders;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 
 namespace Atlas.MatchingAlgorithm.Functions.Functions
 {
-    public class HlaMetadataDictionaryFunction //TODO: ATLAS-262 (MDM) migrate to new project
+    public class HlaMetadataDictionaryFunctions //TODO: ATLAS-262 (MDM) migrate to new project
     {
         private readonly IHlaMetadataDictionary hlaMetadataDictionary;
 
-        public HlaMetadataDictionaryFunction(
+        public HlaMetadataDictionaryFunctions(
             IHlaMetadataDictionaryFactory factory,
             IActiveHlaVersionAccessor hlaVersionAccessor)
         {
-            this.hlaMetadataDictionary = factory.BuildDictionary(hlaVersionAccessor.GetActiveHlaDatabaseVersion());
+            hlaMetadataDictionary = factory.BuildDictionary(hlaVersionAccessor.GetActiveHlaDatabaseVersion());
         }
 
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("RefreshHlaMetadataDictionary")]
-        public async Task Refresh([HttpTrigger] HttpRequest httpRequest)
+        [FunctionName(nameof(RefreshHlaMetadataDictionary))]
+        public async Task RefreshHlaMetadataDictionary([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest httpRequest)
         {
             await hlaMetadataDictionary.RecreateHlaMetadataDictionary(CreationBehaviour.Latest);
         }

--- a/Atlas.MatchingAlgorithm.Functions/Functions/ScoringFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/ScoringFunctions.cs
@@ -6,22 +6,23 @@ using Atlas.MatchingAlgorithm.Client.Models.Scoring;
 using Atlas.MatchingAlgorithm.Services.Search.Scoring;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Newtonsoft.Json;
 
 namespace Atlas.MatchingAlgorithm.Functions.Functions
 {
-    public class Scoring
+    public class ScoringFunctions
     {
         private readonly IScoringRequestService scoringRequestService;
 
-        public Scoring(IScoringRequestService scoringRequestService)
+        public ScoringFunctions(IScoringRequestService scoringRequestService)
         {
             this.scoringRequestService = scoringRequestService;
         }
 
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("Score")]
-        public async Task<ScoringResult> Score([HttpTrigger] HttpRequest httpRequest)
+        [FunctionName(nameof(Score))]
+        public async Task<ScoringResult> Score([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest httpRequest)
         {
             var scoringRequest = JsonConvert.DeserializeObject<ScoringRequest>(await new StreamReader(httpRequest.Body).ReadToEndAsync());
             return await scoringRequestService.Score(scoringRequest);

--- a/Atlas.MatchingAlgorithm.Functions/Functions/ServiceStatusFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/ServiceStatusFunctions.cs
@@ -3,15 +3,16 @@ using System.Reflection;
 using Atlas.Common.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using ServiceStatusModel = Atlas.Common.Utils.Models.ServiceStatus;
 
 namespace Atlas.MatchingAlgorithm.Functions.Functions
 {
-    public class ServiceStatus
+    public class ServiceStatusFunctions
     {
         [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName("ServiceStatus")]
-        public ServiceStatusModel GetServiceStatus([HttpTrigger] HttpRequest request)
+        [FunctionName(nameof(ServiceStatus))]
+        public ServiceStatusModel ServiceStatus([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest request)
         {
             var assembly = Assembly.GetExecutingAssembly();
             var name = assembly.GetCustomAttribute<AssemblyTitleAttribute>()?.Title;

--- a/Atlas.MatchingAlgorithm.Functions/Functions/SwaggerFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/SwaggerFunctions.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http;
+using AzureFunctions.Extensions.Swashbuckle;
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace Atlas.MatchingAlgorithm.Functions.Functions
+{
+    public static class SwaggerFunctions
+    {
+        [SwaggerIgnore]
+        [FunctionName(nameof(Swagger))]
+        public static HttpResponseMessage Swagger(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/json")]
+            HttpRequestMessage req,
+            [SwashBuckleClient] ISwashBuckleClient swashBuckleClient)
+        {
+            return swashBuckleClient.CreateSwaggerDocumentResponse(req);
+        }
+
+        [SwaggerIgnore]
+        [FunctionName(nameof(SwaggerUi))]
+        public static HttpResponseMessage SwaggerUi(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/ui")]
+            HttpRequestMessage req,
+            [SwashBuckleClient] ISwashBuckleClient swashBuckleClient)
+        {
+            return swashBuckleClient.CreateSwaggerUIResponse(req, "swagger/json");
+        }
+    }
+}

--- a/Atlas.MatchingAlgorithm.Functions/SwaggerStartup.cs
+++ b/Atlas.MatchingAlgorithm.Functions/SwaggerStartup.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using Atlas.MatchingAlgorithm.Functions;
+using AzureFunctions.Extensions.Swashbuckle;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+
+[assembly: FunctionsStartup(typeof(SwashBuckleStartup))]
+namespace Atlas.MatchingAlgorithm.Functions
+{
+    internal class SwashBuckleStartup : IWebJobsStartup
+    {
+        public void Configure(IWebJobsBuilder builder)
+        {
+            builder.AddSwashBuckle(Assembly.GetExecutingAssembly());
+        }
+    }
+}


### PR DESCRIPTION
- rename all functions entry points `XFunctions`
- add Swagger to all functions apps with HTTP functions
- use nameof() for consistency of function names with method names

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/153)
<!-- Reviewable:end -->
