### PR TITLE
fix: ATLAS-235: Correctly compare hashsets when deciding whether to iterate all haplotypes in likelihood service

### DIFF
--- a/Atlas.MatchPrediction/Services/GenotypeLikelihood/GenotypeLikelihoodService.cs
+++ b/Atlas.MatchPrediction/Services/GenotypeLikelihood/GenotypeLikelihoodService.cs
@@ -62,7 +62,7 @@ namespace Atlas.MatchPrediction.Services.GenotypeLikelihood
         {
             if (!haplotypesWithFrequencies.TryGetValue(hla, out var frequency))
             {
-                if (allowedLoci != LocusSettings.MatchPredictionLoci.ToHashSet() && frequency == default)
+                if (!allowedLoci.SetEquals(LocusSettings.MatchPredictionLoci.ToHashSet()) && frequency == default)
                 {
                     frequency = haplotypesWithFrequencies
                         .Where(kvp => kvp.Key.EqualsAtLoci(hla, allowedLoci)).Select(kvp => kvp.Value)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/354)
<!-- Reviewable:end -->
