### PR TITLE
refactor: ATLAS-615: Use shared model for 3x probability values, between overall and per-locus

### DIFF
--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/ExcludedLociTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/ExcludedLociTests.cs
@@ -111,7 +111,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(expectedZeroMismatchProbability);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(expectedZeroMismatchProbability);
         }
     }
 }

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/HaplotypeFrequencySetSelection.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/HaplotypeFrequencySetSelection.cs
@@ -66,7 +66,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
             // We are expecting to use DefaultHaplotypeFrequencySetOption2, which will have a one mismatch probability of 50%.
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(50);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(50);
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
             // We are expecting to use DefaultHaplotypeFrequencySetOption2, which will have a one mismatch probability of 50%.
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(50);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(50);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
             // We are expecting to use DefaultHaplotypeFrequencySetOption1, which will have a one mismatch probability of 11%.
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(11);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(11);
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
             // This test uses a combination of DefaultHaplotypeFrequencySetOption2 and DefaultHaplotypeFrequencySetOption3
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(80);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(80);
         }
     }
 }

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MatchProbabilityTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MatchProbabilityTests.cs
@@ -31,9 +31,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Should().Be(null);
-            matchDetails.OneMismatchProbability.Should().Be(null);
-            matchDetails.TwoMismatchProbability.Should().Be(null);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Should().Be(null);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Should().Be(null);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Should().Be(null);
             matchDetails.ZeroMismatchProbabilityPerLocus.Should().Be(expectedMismatchProbabilityPerLocus);
             matchDetails.OneMismatchProbabilityPerLocus.Should().Be(expectedMismatchProbabilityPerLocus);
             matchDetails.TwoMismatchProbabilityPerLocus.Should().Be(expectedMismatchProbabilityPerLocus);
@@ -58,9 +58,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Decimal.Should().Be(1m);
-            matchDetails.OneMismatchProbability.Decimal.Should().Be(0m);
-            matchDetails.TwoMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(1m);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0m);
             matchDetails.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedZeroMismatchProbabilityPerLocus);
             matchDetails.OneMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedOneMismatchProbabilityPerLocus);
             matchDetails.TwoMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedTwoMismatchProbabilityPerLocus);
@@ -117,9 +117,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Decimal.Should().Be(0m);
-            matchDetails.OneMismatchProbability.Decimal.Should().Be(0m);
-            matchDetails.TwoMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0m);
             matchDetails.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedZeroMismatchProbabilityPerLocus);
             matchDetails.OneMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedOneMismatchProbabilityPerLocus);
             matchDetails.TwoMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedTwoMismatchProbabilityPerLocus);
@@ -204,9 +204,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Decimal.Should().Be(0.008230452674897119341563786m);
-            matchDetails.OneMismatchProbability.Decimal.Should().Be(0.1687242798353909465020576132m);
-            matchDetails.TwoMismatchProbability.Decimal.Should().Be(0.8230452674897119341563786008m);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(0.008230452674897119341563786m);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(0.1687242798353909465020576132m);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0.8230452674897119341563786008m);
             matchDetails.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedZeroMismatchProbabilityPerLocus);
             matchDetails.OneMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedOneMismatchProbabilityPerLocus);
             matchDetails.TwoMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedTwoMismatchProbabilityPerLocus);
@@ -292,9 +292,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Decimal.Should().Be(0.012345679012345679012345679m);
-            matchDetails.OneMismatchProbability.Decimal.Should().Be(0.1975308641975308641975308642m);
-            matchDetails.TwoMismatchProbability.Decimal.Should().Be(0.7901234567901234567901234568m);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(0.012345679012345679012345679m);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(0.1975308641975308641975308642m);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0.7901234567901234567901234568m);
             matchDetails.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedZeroMismatchProbabilityPerLocus);
             matchDetails.OneMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedOneMismatchProbabilityPerLocus);
             matchDetails.TwoMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedTwoMismatchProbabilityPerLocus);
@@ -319,7 +319,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchProbability = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchProbability.ZeroMismatchProbability.Percentage.Should().Be(22);
+            matchProbability.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(22);
         }
 
         // These test cases were calculated by hand to ensure we are asserting the correct percentages
@@ -360,7 +360,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchProbability = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchProbability.ZeroMismatchProbability.Percentage.Should().Be(expectedZeroMismatchPercentage);
+            matchProbability.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(expectedZeroMismatchPercentage);
         }
     }
 }

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MissingLociTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MissingLociTests.cs
@@ -122,9 +122,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(zeroMismatchProbability);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(oneMismatchProbability);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(twoMismatchProbability);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(zeroMismatchProbability);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(oneMismatchProbability);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(twoMismatchProbability);
         }
     }
 }

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/PerformanceBenchmarks.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/PerformanceBenchmarks.cs
@@ -70,9 +70,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(73);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(23);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(3);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(73);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(23);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(3);
         }
 
         [Test]
@@ -96,9 +96,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(100);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(0);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(0);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(100);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(0);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(0);
         }
 
         [Test]
@@ -122,9 +122,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(99);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(1);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(0);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(99);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(1);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(0);
         }
 
         [Test]
@@ -146,9 +146,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(97);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(3);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(0);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(97);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(3);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(0);
         }
 
         [Test]
@@ -170,9 +170,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(96);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(4);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(0);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(96);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(4);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(0);
         }
 
         [Test]
@@ -197,9 +197,9 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.ZeroMismatchProbability.Percentage.Should().Be(93);
-            matchDetails.OneMismatchProbability.Percentage.Should().Be(7);
-            matchDetails.TwoMismatchProbability.Percentage.Should().Be(0);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(93);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(7);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(0);
         }
 
         private static async Task ImportHaplotypeFrequencies()

--- a/Atlas.MatchPrediction.Test/Models/MatchProbabilityResponseTests.cs
+++ b/Atlas.MatchPrediction.Test/Models/MatchProbabilityResponseTests.cs
@@ -19,9 +19,9 @@ namespace Atlas.MatchPrediction.Test.Models
 
             var roundedResponse = unRoundedResponse.Round(4);
 
-            roundedResponse.ZeroMismatchProbability.Decimal.Should().Be(rounded);
-            roundedResponse.OneMismatchProbability.Decimal.Should().Be(rounded);
-            roundedResponse.TwoMismatchProbability.Decimal.Should().Be(rounded);
+            roundedResponse.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(rounded);
+            roundedResponse.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(rounded);
+            roundedResponse.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(rounded);
             roundedResponse.ZeroMismatchProbabilityPerLocus.Should().BeEquivalentTo(new LociInfo<Probability>(new Probability(rounded)));
             roundedResponse.OneMismatchProbabilityPerLocus.Should().BeEquivalentTo(new LociInfo<Probability>(new Probability(rounded)));
             roundedResponse.TwoMismatchProbabilityPerLocus.Should().BeEquivalentTo(new LociInfo<Probability>(new Probability(rounded)));
@@ -34,9 +34,9 @@ namespace Atlas.MatchPrediction.Test.Models
 
             var roundedResponse = unRoundedResponse.Round(4);
 
-            roundedResponse.ZeroMismatchProbability.Should().BeNull();
-            roundedResponse.OneMismatchProbability.Should().BeNull();
-            roundedResponse.TwoMismatchProbability.Should().BeNull();
+            roundedResponse.MatchProbabilities.ZeroMismatchProbability.Should().BeNull();
+            roundedResponse.MatchProbabilities.OneMismatchProbability.Should().BeNull();
+            roundedResponse.MatchProbabilities.TwoMismatchProbability.Should().BeNull();
             roundedResponse.ZeroMismatchProbabilityPerLocus.Should().BeEquivalentTo(new LociInfo<Probability>(null));
             roundedResponse.OneMismatchProbabilityPerLocus.Should().BeEquivalentTo(new LociInfo<Probability>(null));
             roundedResponse.TwoMismatchProbabilityPerLocus.Should().BeEquivalentTo(new LociInfo<Probability>(null));

--- a/Atlas.MatchPrediction.Test/Services/MatchProbability/MatchProbabilityCalculatorTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/MatchProbability/MatchProbabilityCalculatorTests.cs
@@ -56,7 +56,7 @@ namespace Atlas.MatchPrediction.Test.Services.MatchProbability
             );
 
             var expectedMatchProbabilityPerLocus = new LociInfo<decimal?> {A = 0.5M, B = 0.5M, C = 0.5M, Dpb1 = null, Dqb1 = 0.25M, Drb1 = 0.25M};
-            actualProbability.ZeroMismatchProbability.Decimal.Should().Be(0.25m);
+            actualProbability.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(0.25m);
             actualProbability.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedMatchProbabilityPerLocus);
         }
 
@@ -87,7 +87,7 @@ namespace Atlas.MatchPrediction.Test.Services.MatchProbability
             );
 
             var expectedMatchProbabilityPerLocus = new LociInfo<decimal?> {A = 0.5M, B = 0.5M, C = 0.5M, Dpb1 = null, Dqb1 = 0.5M, Drb1 = 0.25M};
-            actualProbability.OneMismatchProbability.Decimal.Should().Be(0.25m);
+            actualProbability.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(0.25m);
             actualProbability.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedMatchProbabilityPerLocus);
         }
 
@@ -118,7 +118,7 @@ namespace Atlas.MatchPrediction.Test.Services.MatchProbability
             );
 
             var expectedMatchProbabilityPerLocus = new LociInfo<decimal?> {A = 0.5M, B = 0.5M, C = 0.5M, Dpb1 = null, Dqb1 = 0.5M, Drb1 = 0.25M};
-            actualProbability.TwoMismatchProbability.Decimal.Should().Be(0.25m);
+            actualProbability.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0.25m);
             actualProbability.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedMatchProbabilityPerLocus);
         }
 
@@ -149,7 +149,7 @@ namespace Atlas.MatchPrediction.Test.Services.MatchProbability
             );
 
             var expectedMatchProbabilityPerLocus = new LociInfo<decimal?> {A = 0.5M, B = 0.25M, C = 0.25M, Dpb1 = null, Dqb1 = 0.5M, Drb1 = 0.5M};
-            actualProbability.TwoMismatchProbability.Decimal.Should().Be(0.25m);
+            actualProbability.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0.25m);
             actualProbability.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedMatchProbabilityPerLocus);
         }
 
@@ -178,7 +178,7 @@ namespace Atlas.MatchPrediction.Test.Services.MatchProbability
                 AllowedLoci
             );
 
-            actualProbability.ZeroMismatchProbability.Decimal.Should().Be(0.1428571428571428571428571429m);
+            actualProbability.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(0.1428571428571428571428571429m);
         }
     }
 }

--- a/Atlas.MatchPrediction.Test/TestHelpers/Builders/MatchProbabilityResponseBuilder.cs
+++ b/Atlas.MatchPrediction.Test/TestHelpers/Builders/MatchProbabilityResponseBuilder.cs
@@ -1,5 +1,6 @@
 using Atlas.Common.GeneticData.PhenotypeInfo;
 using Atlas.Common.Utils.Models;
+using Atlas.MatchPrediction.ExternalInterface.Models.MatchProbability;
 using LochNessBuilder;
 using Builder = LochNessBuilder.Builder<Atlas.MatchPrediction.ExternalInterface.Models.MatchProbability.MatchProbabilityResponse>;
 
@@ -12,24 +13,21 @@ namespace Atlas.MatchPrediction.Test.TestHelpers.Builders
 
         public static Builder WithAllProbabilityValuesSetTo(this Builder builder, decimal value)
         {
-            return builder
-                .With(r => r.ZeroMismatchProbability, new Probability(value))
-                .With(r => r.OneMismatchProbability, new Probability(value))
-                .With(r => r.TwoMismatchProbability, new Probability(value))
-                .With(r => r.ZeroMismatchProbabilityPerLocus, new LociInfo<Probability>(new Probability(value)))
-                .With(r => r.OneMismatchProbabilityPerLocus, new LociInfo<Probability>(new Probability(value)))
-                .With(r => r.TwoMismatchProbabilityPerLocus, new LociInfo<Probability>(new Probability(value)));
+            return builder.WithAllProbabilityValuesSetTo((decimal?) value);
         }
-        
+
         public static Builder WithAllProbabilityValuesNull(this Builder builder)
         {
+            return builder.WithAllProbabilityValuesSetTo(null);
+        }
+
+        private static Builder WithAllProbabilityValuesSetTo(this Builder builder, decimal? value)
+        {
+            var matchProbabilities = new MatchProbabilities(value != null ? new Probability(value.Value) : null);
+
             return builder
-                .With(r => r.ZeroMismatchProbability, (Probability) null)
-                .With(r => r.OneMismatchProbability, (Probability) null)
-                .With(r => r.TwoMismatchProbability, (Probability) null)
-                .With(r => r.ZeroMismatchProbabilityPerLocus, new LociInfo<Probability>(null))
-                .With(r => r.OneMismatchProbabilityPerLocus, new LociInfo<Probability>(null))
-                .With(r => r.TwoMismatchProbabilityPerLocus, new LociInfo<Probability>(null));
+                .With(r => r.MatchProbabilities, matchProbabilities)
+                .With(r => r.MatchProbabilitiesPerLocus, new LociInfo<MatchProbabilities>(matchProbabilities));
         }
     }
 }

--- a/Atlas.MatchPrediction/Services/MatchProbability/MatchProbabilityCalculator.cs
+++ b/Atlas.MatchPrediction/Services/MatchProbability/MatchProbabilityCalculator.cs
@@ -85,18 +85,24 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
 
             return new MatchProbabilityResponse
             {
-                ZeroMismatchProbability = new Probability(MatchProbability(matchProbabilityNumerators.ZeroMismatchProbability)),
-                OneMismatchProbability = new Probability(MatchProbability(matchProbabilityNumerators.OneMismatchProbability)),
-                TwoMismatchProbability = new Probability(MatchProbability(matchProbabilityNumerators.TwoMismatchProbability)),
-                ZeroMismatchProbabilityPerLocus = matchProbabilityNumerators.ZeroMismatchProbabilityPerLocus.Map((l, v) =>
-                    v.HasValue ? new Probability(MatchProbability(v.Value)) : null
-                ),
-                OneMismatchProbabilityPerLocus = matchProbabilityNumerators.OneMismatchProbabilityPerLocus.Map((l, v) =>
-                    v.HasValue ? new Probability(MatchProbability(v.Value)) : null
-                ),
-                TwoMismatchProbabilityPerLocus = matchProbabilityNumerators.TwoMismatchProbabilityPerLocus.Map((l, v) =>
-                    v.HasValue ? new Probability(MatchProbability(v.Value)) : null
-                )
+                MatchProbabilities = new MatchProbabilities
+                {
+                    ZeroMismatchProbability = new Probability(MatchProbability(matchProbabilityNumerators.ZeroMismatchProbability)),
+                    OneMismatchProbability = new Probability(MatchProbability(matchProbabilityNumerators.OneMismatchProbability)),
+                    TwoMismatchProbability = new Probability(MatchProbability(matchProbabilityNumerators.TwoMismatchProbability)),
+                },
+                MatchProbabilitiesPerLocus = new LociInfo<MatchProbabilities>().Map((locus, _) =>
+                {
+                    var zeroMismatch = matchProbabilityNumerators.ZeroMismatchProbabilityPerLocus.GetLocus(locus);
+                    var oneMismatch = matchProbabilityNumerators.OneMismatchProbabilityPerLocus.GetLocus(locus);
+                    var twoMismatch = matchProbabilityNumerators.TwoMismatchProbabilityPerLocus.GetLocus(locus);
+                    return new MatchProbabilities
+                    {
+                        ZeroMismatchProbability = zeroMismatch.HasValue ? new Probability(MatchProbability(zeroMismatch.Value)) : null,
+                        OneMismatchProbability = oneMismatch.HasValue ? new Probability(MatchProbability(oneMismatch.Value)) : null,
+                        TwoMismatchProbability = twoMismatch.HasValue ? new Probability(MatchProbability(twoMismatch.Value)) : null,
+                    };
+                })
             };
         }
 
@@ -144,7 +150,7 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
                 {
                     if (!allowedLoci.Contains(locus))
                     {
-                        return (decimal?)null;
+                        return (decimal?) null;
                     }
 
                     if (pair.MatchCounts.GetLocus(locus) == 2 - mismatchesPerLocus)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/411)
<!-- Reviewable:end -->
