### PR TITLE
refactor: ATLAS-595: Do not calculate "ExpressingHlaMatch" more than once per allele pair.

### DIFF
--- a/Atlas.Common/ApplicationInsights/Timing/LongOperationLoggingStopwatch.cs
+++ b/Atlas.Common/ApplicationInsights/Timing/LongOperationLoggingStopwatch.cs
@@ -137,7 +137,7 @@ namespace LoggingStopwatch
                 try
                 {
                     var elapsedOuterTime_MS = outerStopwatch.ElapsedMilliseconds; //Dont pass in just the ElapsedMillis, since that's not completely trivial for it to calculate.
-                    var logMessage = $"Progress: ({newCompletedCount}) operations completed.";
+                    var logMessage = $"Progress: ({newCompletedCount}) operations completed. ";
 
                     if (settings.ExpectedNumberOfIterations.HasValue)
                     {
@@ -145,7 +145,7 @@ namespace LoggingStopwatch
 
                         if (settings.ReportPercentageCompletion)
                         {
-                            logMessage += $"|{completionPercentage:0.00%}";
+                            logMessage += $"|{completionPercentage:0.00%} ";
                         }
 
                         if (settings.ReportProjectedCompletionTime)

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/PerformanceBenchmarks.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/PerformanceBenchmarks.cs
@@ -76,7 +76,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
         }
 
         [Test]
-        // Runs in ~1s. Quick enough to not ignore.
+        // Runs in ~0.1s. Quick enough to not ignore.
         public async Task MatchPrediction__WithDonorFullyTyped_AtTruncatedTwoFieldAlleleResolution__CalculatesProbabilityCorrectly()
         {
             var donorHla = new PhenotypeInfoBuilder<string>()


### PR DESCRIPTION
- doesn't appear to noticeably affect performance, but I think still worth doing in case it became a bottleneck later
(It could be that this gets compiled to the same thing by C# anyway, but I don't think the new code is actively worse)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/417)
<!-- Reviewable:end -->
