### PR TITLE
feature: ATLAS-578: Calculate typed loci count for all loci

### DIFF
--- a/Atlas.MatchingAlgorithm.Client.Models/SearchResults/MatchingAlgorithmResult.cs
+++ b/Atlas.MatchingAlgorithm.Client.Models/SearchResults/MatchingAlgorithmResult.cs
@@ -51,6 +51,12 @@ namespace Atlas.MatchingAlgorithm.Client.Models.SearchResults
         /// The number of loci which are typed for this donor.
         /// Loci excluded from scoring and aggregation will not be included, regardless of whether they are typed.
         /// </summary>
+        public int? TypedLociCountAtScoredLoci { get; set; }
+        
+        /// <summary>
+        /// The number of loci which are typed for this donor.
+        /// This will be calculated for all loci, regardless of whether they were excluded from scoring aggregation.
+        /// </summary>
         public int? TypedLociCount { get; set; }
 
         /// <summary>

--- a/Atlas.MatchingAlgorithm.Data/Models/SearchResults/MatchResult.cs
+++ b/Atlas.MatchingAlgorithm.Data/Models/SearchResults/MatchResult.cs
@@ -14,15 +14,16 @@ namespace Atlas.MatchingAlgorithm.Data.Models.SearchResults
         private DonorInfo.DonorInfo donorInfo;
 
         #region Partial donor information used in matching
-        
+
         // Stored separately from the donors, as the lookup in the matches table only returns the id
         // We don't want to populate the full donor object until some filtering has been applied on those results
         public int DonorId { get; set; }
+
         // Stored separately from the Donor object as we don't want to populate all donor data until we're done filtering
         public PhenotypeInfo<IEnumerable<string>> DonorPGroups { get; set; }
 
         #endregion
-        
+
         public DonorInfo.DonorInfo DonorInfo
         {
             get
@@ -40,6 +41,7 @@ namespace Atlas.MatchingAlgorithm.Data.Models.SearchResults
                 {
                     throw new ReadOnlyException("Matching data cannot be changed after it has been marked as fully populated");
                 }
+
                 donorInfo = value;
             }
         }
@@ -53,7 +55,7 @@ namespace Atlas.MatchingAlgorithm.Data.Models.SearchResults
         /// </summary>
         public IEnumerable<Locus> MatchedLoci => EnumerateValues<Locus>()
             .Where(l => MatchDetailsForLocus(l) != null);
-        
+
         private IEnumerable<LocusMatchDetails> LocusMatchDetails => new List<LocusMatchDetails>
         {
             MatchDetailsAtLocusA,
@@ -109,14 +111,14 @@ namespace Atlas.MatchingAlgorithm.Data.Models.SearchResults
 
             return matchDetails;
         }
-        
+
         public void SetMatchDetailsForLocus(Locus locus, LocusMatchDetails locusMatchDetails)
         {
             if (isMatchingDataFullyPopulated)
             {
                 throw new ReadOnlyException("Matching data cannot be changed after it has been marked as fully populated");
             }
-            
+
             switch (locus)
             {
                 case Locus.A:
@@ -146,5 +148,7 @@ namespace Atlas.MatchingAlgorithm.Data.Models.SearchResults
         {
             isMatchingDataFullyPopulated = true;
         }
+
+        public int TypedLociCount => DonorInfo.HlaNames.Reduce((_, hla, count) => hla.Position1And2NotNull() ? count + 1 : count, 0);
     }
 }

--- a/Atlas.MatchingAlgorithm.Test.Integration/IntegrationTests/Search/ScoringTests.cs
+++ b/Atlas.MatchingAlgorithm.Test.Integration/IntegrationTests/Search/ScoringTests.cs
@@ -71,10 +71,26 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Search
             var results = await searchService.Search(searchRequest);
             var result = results.SingleOrDefault(d => d.AtlasDonorId == testDonor.DonorId);
 
-            result.TypedLociCount.Should().BeNull();
+            result.TypedLociCountAtScoredLoci.Should().BeNull();
             result.GradeScore.Should().BeNull();
             result.ConfidenceScore.Should().BeNull();
             result.MatchCategory.Should().BeNull();
+        }
+        
+        [Test]
+        public async Task Search_ScoreNoLoci_ReturnsTypedLociCount()
+        {
+            var searchRequest = new SearchRequestFromHlasBuilder(
+                    defaultHlaSet.SixLocus_SingleExpressingAlleles,
+                    mismatchHlaSet.SixLocus_SingleExpressingAlleles)
+                .TenOutOfTen()
+                .WithLociToScore(new List<Locus>())
+                .Build();
+
+            var results = await searchService.Search(searchRequest);
+            var result = results.SingleOrDefault(d => d.AtlasDonorId == testDonor.DonorId);
+
+            result?.TypedLociCount.Should().Be(6);
         }
 
         [Test]
@@ -90,7 +106,7 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Search
             var results = await searchService.Search(searchRequest);
             var result = results.SingleOrDefault(d => d.AtlasDonorId == testDonor.DonorId);
 
-            result.TypedLociCount.Should().Be(1);
+            result.TypedLociCountAtScoredLoci.Should().Be(1);
             result.GradeScore.Should().NotBeNull();
             result.ConfidenceScore.Should().NotBeNull();
             result.MatchCategory.Should().NotBeNull();
@@ -109,7 +125,7 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Search
             var results = await searchService.Search(searchRequest);
             var result = results.SingleOrDefault(d => d.AtlasDonorId == testDonor.DonorId);
 
-            result.TypedLociCount.Should().Be(6);
+            result.TypedLociCountAtScoredLoci.Should().Be(6);
             result.GradeScore.Should().NotBeNull();
             result.ConfidenceScore.Should().NotBeNull();
             result.MatchCategory.Should().NotBeNull();

--- a/Atlas.MatchingAlgorithm.Test.Validation/ValidationTests/StepDefinitions/ScoringSteps.cs
+++ b/Atlas.MatchingAlgorithm.Test.Validation/ValidationTests/StepDefinitions/ScoringSteps.cs
@@ -120,7 +120,7 @@ namespace Atlas.MatchingAlgorithm.Test.Validation.ValidationTests.StepDefinition
         public void ThenTheMatchConfidenceShouldBe(int typedLociCount)
         {
             var donorResult = GetSearchResultForSingleDonor();
-            donorResult.TypedLociCount.Should().Be(typedLociCount);
+            donorResult.TypedLociCountAtScoredLoci.Should().Be(typedLociCount);
         }
 
         private MatchingAlgorithmResult GetSearchResultForSingleDonor()

--- a/Atlas.MatchingAlgorithm/Services/Search/SearchService.cs
+++ b/Atlas.MatchingAlgorithm/Services/Search/SearchService.cs
@@ -126,15 +126,16 @@ namespace Atlas.MatchingAlgorithm.Services.Search
                 AtlasDonorId = result.MatchResult.DonorInfo.DonorId,
                 DonorType = result.MatchResult.DonorInfo.DonorType,
 
-                //matching results
+                // matching results
                 TotalMatchCount = result.MatchResult.TotalMatchCount,
                 DonorHla = result.MatchResult.DonorInfo.HlaNames,
+                TypedLociCount = result.MatchResult.TypedLociCount,
 
                 // scoring results
                 MatchCategory = result.ScoreResult?.AggregateScoreDetails.MatchCategory,
                 ConfidenceScore = result.ScoreResult?.AggregateScoreDetails.ConfidenceScore,
                 GradeScore = result.ScoreResult?.AggregateScoreDetails.GradeScore,
-                TypedLociCount = result.ScoreResult?.AggregateScoreDetails.TypedLociCount,
+                TypedLociCountAtScoredLoci = result.ScoreResult?.AggregateScoreDetails.TypedLociCount,
 
                 // combines both matching and scoring results
                 PotentialMatchCount = result.PotentialMatchCount,


### PR DESCRIPTION
- Keep returning a typed loci count at scored loci only as well, as AN are expected to keep using this as a way of disabling DPB1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/420)
<!-- Reviewable:end -->
