### PR TITLE
fix: ATLAS-699: Remove cleanup notification for data refresh

### DIFF
--- a/Atlas.MatchingAlgorithm.Functions/Functions/DataRefreshFunctions.cs
+++ b/Atlas.MatchingAlgorithm.Functions/Functions/DataRefreshFunctions.cs
@@ -73,15 +73,5 @@ namespace Atlas.MatchingAlgorithm.Functions.Functions
         {
             await dataRefreshCleanupService.RunDataRefreshCleanup();
         }
-
-        /// <summary>
-        /// On start-up, checks for in-progress jobs - if any are present, implies teardown was not completed - so notifies the support team.
-        /// </summary>
-        [SuppressMessage(null, SuppressMessage.UnusedParameter, Justification = SuppressMessage.UsedByAzureTrigger)]
-        [FunctionName(nameof(CheckIfCleanupNecessary))]
-        public async Task CheckIfCleanupNecessary([TimerTrigger("00 00 11 01 06 *", RunOnStartup = true)] TimerInfo timerInfo)
-        {
-            await dataRefreshCleanupService.SendCleanupRecommendation();
-        }
     }
 }

--- a/Atlas.MatchingAlgorithm.Test/Services/DataRefresh/DataRefreshCleanupServiceTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Services/DataRefresh/DataRefreshCleanupServiceTests.cs
@@ -117,26 +117,6 @@ namespace Atlas.MatchingAlgorithm.Test.Services.DataRefresh
             await notificationSender.Received().SendRequestManualTeardownNotification();
         }
 
-        [Test]
-        public async Task SendCleanupRecommendation_WhenJobsInProgress_SendsAlert()
-        {
-            dataRefreshHistoryRepository.GetInProgressJobs().Returns(new List<DataRefreshRecord> {new DataRefreshRecord()});
-
-            await dataRefreshCleanupService.SendCleanupRecommendation();
-
-            await notificationSender.Received().SendRecommendManualCleanupAlert();
-        }
-
-        [Test]
-        public async Task SendCleanupRecommendation_WhenNoJobsInProgress_DoesNotSendAlert()
-        {
-            dataRefreshHistoryRepository.GetInProgressJobs().Returns(new List<DataRefreshRecord>());
-
-            await dataRefreshCleanupService.SendCleanupRecommendation();
-
-            await notificationSender.DidNotReceive().SendRecommendManualCleanupAlert();
-        }
-
         private DataRefreshCleanupService BuildDataRefreshCleanupService(DataRefreshSettings dataRefreshSettings = null)
         {
             var settings = dataRefreshSettings ?? new DataRefreshSettings {DormantDatabaseSize = "S0"};

--- a/Atlas.MatchingAlgorithm/Services/DataRefresh/DataRefreshCleanupService.cs
+++ b/Atlas.MatchingAlgorithm/Services/DataRefresh/DataRefreshCleanupService.cs
@@ -19,15 +19,6 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh
         /// This should only ever be run manually, and only if the server dies in the middle of data-refresh, as the normal teardown will not have run.
         /// </summary>
         Task RunDataRefreshCleanup();
-
-        /// <summary>
-        /// Will decide whether we think clean up needs to be run, and if so send a notification for the support team.
-        /// This is only accurate if the following are true:
-        /// - This class is called from the same service as runs the data refresh
-        /// - That service is a single instance, always-on application
-        /// - This is only called on startup of the service
-        /// </summary>
-        Task SendCleanupRecommendation();
     }
 
     public class DataRefreshCleanupService : IDataRefreshCleanupService
@@ -72,14 +63,6 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh
             else
             {
                 logger.SendTrace("Data Refresh cleanup triggered, but no in progress jobs detected. Cleanup is not necessary.");
-            }
-        }
-
-        public async Task SendCleanupRecommendation()
-        {
-            if (IsCleanupNecessary())
-            {
-                await notificationSender.SendRecommendManualCleanupAlert();
             }
         }
 

--- a/Atlas.MatchingAlgorithm/Services/DataRefresh/Notifications/DataRefreshSupportNotificationSender.cs
+++ b/Atlas.MatchingAlgorithm/Services/DataRefresh/Notifications/DataRefreshSupportNotificationSender.cs
@@ -15,7 +15,6 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh.Notifications
         Task SendFailureAlert(int recordId);
         Task SendTeardownFailureAlert(int recordId);
         Task SendRequestManualTeardownNotification();
-        Task SendRecommendManualCleanupAlert();
     }
     
     public class DataRefreshSupportNotificationSender: IDataRefreshSupportNotificationSender
@@ -100,22 +99,6 @@ Check application insights to track down the failure - the job may need to be re
 Appropriate teardown is being run. The data refresh will need to be re-started once the reason for the server restart has been diagnosed and handled.";
 
             await SendNotification(summary, description);
-        }
-
-        public async Task SendRecommendManualCleanupAlert()
-        {
-            const string summary = "Data Refresh: Manual cleanup recommended.";
-            const string description = 
-@"The algorithm has detected an in-progress data refresh job on startup. This generally implies that a data refresh job 
-was terminated without the appropriate teardown being run - this should only happen if the service was re-started unexpectedly.
-Possible causes could include: (a) the service plan running out of memory (b) an azure outage (c) a deployment of the algorithm service.
-We should confirm that this was the case, and if so, either manually trigger a continuation of the stalled job (via the `ContinueDataRefresh` 
-function) ,or run appropriate clean-up. See the README of the Atlas.MatchingAlgorithm project for more information.
-The function `RunDataRefreshCleanup` should encapsulate the majority of the necessary clean-up.
-CAVEAT: Due to restrictions of triggers in Azure functions, this function will run once a year not at start-up.
-Check the crontab of the `CheckIfCleanupNecessary` function to ensure it isn't this known false positive.'";
-
-            await SendAlert(summary, description);
         }
     }
 }


### PR DESCRIPTION
Since moving to an elastic plan, this notification is no longer useful.
It triggers when scaling out to a new instance, which happens very soon after the refresh starts due to high CPU usage.

The "RunOnStartup" is not recommended for live applications by Microsoft.

We could get this to keep working by migrating just the data refresh to an app service plan, but provisioning a new app service plan just for this will be more detrimental than removing the notification, as:
- It will mean paying for an app service that isn't being used for most of the year
- Being on a scalable plan should hopefully solve some of the reasons the job has been interrupted in development anyway (due to service worker maintenance in Azure).
- Start/End notifications, combined with AI logging, should give anyone supporting the system enough information about when data refreshes stall.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/494)
<!-- Reviewable:end -->
