### PR TITLE
fix: ATLAS-726: Fixed alert log level

### DIFF
--- a/Atlas.MatchingAlgorithm/Services/DataRefresh/HlaProcessing/HlaProcessor.cs
+++ b/Atlas.MatchingAlgorithm/Services/DataRefresh/HlaProcessing/HlaProcessor.cs
@@ -181,7 +181,7 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh.HlaProcessing
 
             if (failedDonors.Any())
             {
-                await failedDonorsNotificationSender.SendFailedDonorsAlert(failedDonors, HlaFailureEventName, Priority.Low);
+                await failedDonorsNotificationSender.SendFailedDonorsAlert(failedDonors, HlaFailureEventName, Priority.Medium);
             }
         }
 


### PR DESCRIPTION
From looking at everything I think the reason it's not showing up is because of the log level. I've raised it to a medium so its more likely to be seen. LMK if you disagree

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/497)
<!-- Reviewable:end -->
