### PR TITLE
fix: ATLAS-486: Throw more helpfully named exception when MAC could not be found

### DIFF
--- a/Atlas.MultipleAlleleCodeDictionary.Test.Integration/IntegrationTests/MacFetching.cs
+++ b/Atlas.MultipleAlleleCodeDictionary.Test.Integration/IntegrationTests/MacFetching.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Atlas.Common.Test.SharedTestHelpers;
+using Atlas.MultipleAlleleCodeDictionary.AzureStorage.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Atlas.MultipleAlleleCodeDictionary.Test.Integration.IntegrationTests
+{
+    [TestFixture]
+    internal class MacFetching
+    {
+        private IMacRepository macRepository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestStackTraceHelper.CatchAndRethrowWithStackTraceInExceptionMessage(() =>
+            {
+                macRepository = DependencyInjection.DependencyInjection.Provider.GetService<IMacRepository>();
+            });
+        }
+
+        [Test]
+        public async Task GetMac_WhenMacNotFound_ThrowsUsefulException()
+        {
+            await macRepository.Invoking(r => r.GetMac("THIS IS NOT RECOGNISED")).Should().ThrowAsync<MacNotFoundException>();
+        }
+    }
+}

--- a/Atlas.MultipleAlleleCodeDictionary/AzureStorage/Repositories/MacRepository.cs
+++ b/Atlas.MultipleAlleleCodeDictionary/AzureStorage/Repositories/MacRepository.cs
@@ -66,6 +66,10 @@ namespace Atlas.MultipleAlleleCodeDictionary.AzureStorage.Repositories
         public async Task<Mac> GetMac(string macCode)
         {
             var macEntity = await Table.GetByPartitionAndRowKey<MacEntity>(macCode.AsPartitionKey(), macCode.AsRowKey());
+            if (macEntity == null)
+            {
+                throw new MacNotFoundException(macCode);
+            }
             return new Mac(macEntity);
         }
 

--- a/Atlas.MultipleAlleleCodeDictionary/MacNotFoundException.cs
+++ b/Atlas.MultipleAlleleCodeDictionary/MacNotFoundException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Atlas.MultipleAlleleCodeDictionary
+{
+    internal class MacNotFoundException : Exception
+    {
+        public MacNotFoundException(string mac) : base($"MAC {mac} could not be found in the MAC store.")
+        {
+        }
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/526)
<!-- Reviewable:end -->
