### PR TITLE
feature: ATLAS-NONE: Allow search request to specify that mach prediction should not be run

### DIFF
--- a/Atlas.Client.Models/Search/Requests/SearchRequest.cs
+++ b/Atlas.Client.Models/Search/Requests/SearchRequest.cs
@@ -43,6 +43,15 @@ namespace Atlas.Client.Models.Search.Requests
         /// Must match registry code format uploaded with haplotype frequency sets.  
         /// </summary>
         public string PatientRegistryCode { get; set; }
+
+        /// <summary>
+        /// Optional, defaults to true.
+        /// Allows consumer to optionally disable match prediction for search results - match prediction is the most computationally
+        /// expensive and time consuming portion of a search, so if results are not needed, results can be returned much faster without it.
+        ///
+        /// TODO: ATLAS-493: Until this card is completed, matching results without match prediction will be useless to consumers, as they will include the wrong format of donor id. 
+        /// </summary>
+        public bool RunMatchPrediction { get; set; } = true;
     }
     
     public class MismatchCriteria

--- a/Atlas.Functions/DurableFunctions/Search/Client/SearchClientFunctions.cs
+++ b/Atlas.Functions/DurableFunctions/Search/Client/SearchClientFunctions.cs
@@ -40,6 +40,13 @@ namespace Atlas.Functions.DurableFunctions.Search.Client
             [DurableClient] IDurableOrchestrationClient starter)
         {
             var searchId = resultsNotification.SearchRequestId;
+            if (!resultsNotification.SearchRequest.RunMatchPrediction)
+            {
+                logger.SendTrace($"Match prediction for search request '{searchId}' was not requested, so will not be run.");
+                // TODO: ATLAS-493: Make the matching only results usable. 
+                return;
+            }
+
             var instanceId = await starter.StartNewAsync(nameof(SearchOrchestrationFunctions.SearchOrchestrator), resultsNotification);
 
             try


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/571)
<!-- Reviewable:end -->
