### PR TITLE
fix: ATLAS-953: Map scoring potential match count to result's nested scoring info, not overall potential match count

### DIFF
--- a/Atlas.MatchingAlgorithm/Services/Search/SearchService.cs
+++ b/Atlas.MatchingAlgorithm/Services/Search/SearchService.cs
@@ -89,7 +89,7 @@ namespace Atlas.MatchingAlgorithm.Services.Search
                     ConfidenceScore = result.ScoreResult?.AggregateScoreDetails.ConfidenceScore,
                     GradeScore = result.ScoreResult?.AggregateScoreDetails.GradeScore,
                     TypedLociCountAtScoredLoci = result.ScoreResult?.AggregateScoreDetails.TypedLociCount,
-                    PotentialMatchCount = result.PotentialMatchCount,
+                    PotentialMatchCount = result.ScoreResult?.AggregateScoreDetails.PotentialMatchCount ?? 0,
                     ScoringResultsByLocus = new LociInfo<LocusSearchResult>().Map((l, _) => MapSearchResultToApiLocusSearchResult(result, l))
                         .ToLociInfoTransfer(),
                 },


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/585)
<!-- Reviewable:end -->
