### PR TITLE
fix: NOVA-960: Name small g group that is a single null allele after its first two fields and expression suffix.

### DIFF
--- a/Atlas.Common.Test/Hla/Services/AlleleSplitterTests.cs
+++ b/Atlas.Common.Test/Hla/Services/AlleleSplitterTests.cs
@@ -62,6 +62,17 @@ namespace Atlas.Common.Test.Hla.Services
             actualAllele.Should().Be(expectedAllele);
         }
 
+        [TestCase("Field1:Field2:Field3:Field4N", "Field1:Field2N")]
+        [TestCase("Field1:Field2:Field3N", "Field1:Field2N")]
+        [TestCase("Field1:Field2N", "Field1:Field2N")]
+        [TestCase("Field1:Field2", "Field1:Field2")]
+        public void FirstTwoFieldsWithExpressionSuffixAsString_ReturnsFirstTwoFieldsWithExpressionSuffix(string allele, string expectedAllele)
+        {
+            var actualAllele = AlleleSplitter.FirstTwoFieldsWithExpressionSuffixAsString(allele);
+
+            actualAllele.Should().Be(expectedAllele);
+        }
+
         [TestCase("Field:Field", "Field")]
         [TestCase("Field:Field:Field", "Field:Field")]
         [TestCase("Field:Field:Field:Field", "Field:Field:Field")]

--- a/Atlas.Common/GeneticData/Hla/Services/AlleleNameUtils/AlleleSplitter.cs
+++ b/Atlas.Common/GeneticData/Hla/Services/AlleleNameUtils/AlleleSplitter.cs
@@ -22,6 +22,11 @@ namespace Atlas.Common.GeneticData.Hla.Services.AlleleNameUtils
 
         public static string FirstTwoFieldsAsString(string allele) => FirstTwoFields(allele).StringJoin(MolecularTypingNameConstants.FieldDelimiter);
 
+        public static string FirstTwoFieldsWithExpressionSuffixAsString(string allele) =>
+            NumberOfFields(allele) > 2
+                ? FirstTwoFields(allele).StringJoin(MolecularTypingNameConstants.FieldDelimiter) + GetExpressionSuffix(allele)
+                : allele;
+
         public static string RemoveLastField(string allele)
         {
             var splitAllele = SplitToFields(allele).ToList();

--- a/Atlas.HlaMetadataDictionary.Test/IntegrationTests/Tests/SmallGGroupsBuilderTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/IntegrationTests/Tests/SmallGGroupsBuilderTests.cs
@@ -65,6 +65,9 @@ namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.Tests
         [TestCase(Locus.A, "01:52",
             new object[] { "01:52:01N", "01:52:02N" },
             Description = "All Null alleles within small g group")]
+        [TestCase(Locus.Drb1, "04:94N",
+            new object[] { "04:94:01N" },
+            Description = "Single null allele with more than 2 fields")]
         [TestCase(Locus.A, "02:04g",
             new object[] { "02:04", "02:664", "02:710N" },
             Description = "One Null allele within small g group")]

--- a/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/DataGeneration/SmallGGroupsBuilderTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/DataGeneration/SmallGGroupsBuilderTests.cs
@@ -318,11 +318,13 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataGeneration
             smallG.Alleles.Count.Should().Be(1);
         }
 
-        [Test]
-        public void BuildSmallGGroups_SmallGGroupOnlyHasOneAllele_Null_NamesWithAlleleName()
+        [TestCase("01:01N", "01:01N")]
+        [TestCase("01:01:01N", "01:01N")]
+        [TestCase("01:01:01:01N", "01:01N")]
+        public void BuildSmallGGroups_SmallGGroupOnlyHasOneAllele_Null_NamesWithFirst2FieldsAndExpressionSuffix(
+            string nullAllele,
+            string expectedName)
         {
-            const string nullAllele = "01:01N";
-
             var dataset = WmdaDatasetBuilder.New.AddGGroup(LocusName, nullAllele, nullAllele);
 
             wmdaDataRepository.GetWmdaDataset(default).ReturnsForAnyArgs(dataset);
@@ -330,7 +332,7 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataGeneration
             var result = smallGGroupsBuilder.BuildSmallGGroups(DefaultHlaVersion);
             var smallG = result.Single();
 
-            smallG.Name.Should().Be(nullAllele);
+            smallG.Name.Should().Be(expectedName);
 
             smallG.Locus.Should().Be(ExpectedLocus);
             smallG.Alleles.Count.Should().Be(1);

--- a/Atlas.HlaMetadataDictionary/Services/DataGeneration/Generators/SmallGGroupsBuilder.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataGeneration/Generators/SmallGGroupsBuilder.cs
@@ -108,7 +108,9 @@ namespace Atlas.HlaMetadataDictionary.Services.DataGeneration.Generators
                 .Select(groupedAlleles => new SmallGGroup
                 {
                     Locus = GetLocus(locus),
-                    Name = groupedAlleles.Count() == 1 ? groupedAlleles.Single() : groupedAlleles.Key,
+                    Name = groupedAlleles.Count() == 1
+                        ? AlleleSplitter.FirstTwoFieldsWithExpressionSuffixAsString(groupedAlleles.Single())
+                        : groupedAlleles.Key,
                     Alleles = groupedAlleles.ToList()
                 });
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/591)
<!-- Reviewable:end -->
