### PR TITLE
chore: ATLAS-NONE: Reduce bulk insert timeouts in donor import

### DIFF
--- a/Atlas.DonorImport.Data/Repositories/DonorImportLogRepository.cs
+++ b/Atlas.DonorImport.Data/Repositories/DonorImportLogRepository.cs
@@ -97,7 +97,7 @@ namespace Atlas.DonorImport.Data.Repositories
             }
 
             using (var sqlBulk = new SqlBulkCopy(connection)
-                {BulkCopyTimeout = 3600, BatchSize = 10000, DestinationTableName = DonorLog.QualifiedTableName})
+                {BulkCopyTimeout = 300, BatchSize = 10000, DestinationTableName = DonorLog.QualifiedTableName})
             {
                 sqlBulk.ColumnMappings.Add(ExternalDonorCodeColumnName, ExternalDonorCodeColumnName);
                 sqlBulk.ColumnMappings.Add(LastUpdatedColumnName, LastUpdatedColumnName);

--- a/Atlas.DonorImport.Data/Repositories/DonorImportRepository.cs
+++ b/Atlas.DonorImport.Data/Repositories/DonorImportRepository.cs
@@ -95,7 +95,7 @@ namespace Atlas.DonorImport.Data.Repositories
         private SqlBulkCopy BuildDonorSqlBulkCopy()
         {
             var sqlBulk = new SqlBulkCopy(ConnectionString)
-                {BulkCopyTimeout = 3600, BatchSize = 10000, DestinationTableName = Donor.QualifiedTableName};
+                {BulkCopyTimeout = 300, BatchSize = 10000, DestinationTableName = Donor.QualifiedTableName};
 
             foreach (var columnName in Donor.DataTableColumnNamesForInsertion)
             {


### PR DESCRIPTION
In practice we've observed that a bulk insert of 10,000 records takes less than a minute - an hour long timeout seems particularly excessive!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/610)
<!-- Reviewable:end -->
