### PR TITLE
fix: ATLAS-989: Return tce group when allele within allele string/MAC lacks an assignment but remaining alleles share same assignment.

### DIFF
--- a/Atlas.HlaMetadataDictionary.Test/IntegrationTests/Tests/Dpb1TceGroupMetadataServiceTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/IntegrationTests/Tests/Dpb1TceGroupMetadataServiceTests.cs
@@ -16,7 +16,7 @@ namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.Tests
     [TestFixture]
     public class Dpb1TceGroupMetadataServiceTests
     {
-        private const string CacheKey = "NmdpCodeLookup_Dpb1";
+        private const string CacheKey = "MacLookup_Dpb1";
         private const string HlaVersion = FileBackedHlaMetadataRepositoryBaseReader.OlderTestHlaVersion;
 
         private IDpb1TceGroupMetadataService metadataService;
@@ -62,29 +62,46 @@ namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.Tests
         }
 
         [Test]
-        public async Task GetDpb1TceGroup_WhenNmdpCodeMapsToSingleTceGroup_ReturnsTceGroup()
+        public async Task GetDpb1TceGroup_WhenMacMapsToSingleTceGroup_ReturnsTceGroup()
         {
             // both alleles map to same TCE group
             const string tceGroup = "3";
 
             // MAC value here should be represented in Atlas.MultipleAlleleCodeDictionary.Test.Integration.Resources.Mac.csv
-            const string macWithFirstField = "02:ABC";
+            const string mac = "02:ABC";
 
-            var result = await metadataService.GetDpb1TceGroup(macWithFirstField, HlaVersion);
+            var result = await metadataService.GetDpb1TceGroup(mac, HlaVersion);
 
             result.Should().Be(tceGroup);
         }
 
         [Test]
-        public async Task GetDpb1TceGroup_WhenNmdpCodeMapsToMoreThanOneTceGroup_DoesNotReturnTceGroup()
+        public async Task GetDpb1TceGroup_WhenMacMapsToMoreThanOneTceGroup_DoesNotReturnTceGroup()
         {
             // alleles map to different TCE groups
             // MAC value here should be represented in Atlas.MultipleAlleleCodeDictionary.Test.Integration.Resources.Mac.csv
-            const string macWithFirstField = "02:DEF";
+            const string mac = "02:DEF";
 
-            var result = await metadataService.GetDpb1TceGroup(macWithFirstField, HlaVersion);
+            var result = await metadataService.GetDpb1TceGroup(mac, HlaVersion);
 
             result.Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// Regression test
+        /// </summary>
+        [Test]
+        public async Task GetDpb1TceGroup_WhenMacMapsToSingleTceGroup_ButAlsoHasAlleleWithNoTceGroup_ReturnsTceGroup()
+        {
+            // MAC value here should be represented in Atlas.MultipleAlleleCodeDictionary.Test.Integration.Repositories.LargeMacDictionary.csv
+            // TCE => 13:01/548:01
+            // 13:01 = tce group 3; 548:01 = no tce group assigned
+            const string mac = "13:TCE";
+            const string tceGroup = "3";
+
+            var result = await metadataService.GetDpb1TceGroup(mac, HlaVersion);
+
+            result.Should().Be(tceGroup);
         }
 
         [Test]
@@ -124,6 +141,21 @@ namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.Tests
             var result = await metadataService.GetDpb1TceGroup(alleleString, HlaVersion);
 
             result.Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// Regression test
+        /// </summary>
+        [Test]
+        public async Task GetDpb1TceGroup_WhenAlleleStringMapsToSingleTceGroup_ButAlsoHasAlleleWithNoTceGroup_ReturnsTceGroup()
+        {
+            // 13:01 = tce group 3; 548:01 = no tce group assigned
+            const string alleleString = "13:01/548:01";
+            const string tceGroup = "3";
+
+            var result = await metadataService.GetDpb1TceGroup(alleleString, HlaVersion);
+
+            result.Should().Be(tceGroup);
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Dpb1TceGroupMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Dpb1TceGroupMetadataService.cs
@@ -8,6 +8,7 @@ using Atlas.MultipleAlleleCodeDictionary.ExternalInterface;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Atlas.Common.Utils.Extensions;
 
 namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
 {
@@ -65,6 +66,7 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         {
             var tceGroups = metadata
                 .Select(data => data.TceGroup)
+                .Where(tce => !tce.IsNullOrEmpty())
                 .Distinct()
                 .ToList();
 

--- a/Atlas.MatchingAlgorithm.Test.Validation/ValidationTests/Features/Scoring/MatchGrades.feature
+++ b/Atlas.MatchingAlgorithm.Test.Validation/ValidationTests/Features/Scoring/MatchGrades.feature
@@ -163,3 +163,15 @@
     And scoring is enabled at locus A
     When I run a 6/6 search
     Then the match grade should be serology at A at position 1
+
+  Scenario: Permissive mismatch - Donor has DPB1 allele string wherein one allele has a matching TCE assignment, but other has no TCE assignment
+    Given a patient has a match
+    And the matching donor has the following HLA:
+    |A_1    |A_2    |B_1    |B_2    |DRB1_1 |DRB1_2 |DPB1_1 |DPB1_2         |
+    |*01:01 |*66:01 |*57:01 |*41:01 |*13:XX |*07:01 |*01:01 |*191:01/192:01 |
+    And the patient has the following HLA:
+    |A_1    |A_2    |B_1    |B_2    |DRB1_1 |DRB1_2 |DPB1_1 |DPB1_2 |
+    |*01:01 |*66:01 |*57:01 |*41:01 |*13:XX |*07:01 |*01:01 |*02:01 |
+    And scoring is enabled at locus DPB1
+    When I run a 6/6 search
+    Then the match grade should be permissive mismatch at DPB1 at position 2

--- a/Atlas.MatchingAlgorithm.Test.Validation/ValidationTests/Features/Scoring/MatchGrades.feature.cs
+++ b/Atlas.MatchingAlgorithm.Test.Validation/ValidationTests/Features/Scoring/MatchGrades.feature.cs
@@ -1126,6 +1126,93 @@ namespace Atlas.MatchingAlgorithm.Test.Validation.ValidationTests.Features.Scori
             }
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Permissive mismatch - Donor has DPB1 allele string wherein one allele has a match" +
+            "ing TCE assignment, but other has no TCE assignment")]
+        public virtual void PermissiveMismatch_DonorHasDPB1AlleleStringWhereinOneAlleleHasAMatchingTCEAssignmentButOtherHasNoTCEAssignment()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Permissive mismatch - Donor has DPB1 allele string wherein one allele has a match" +
+                    "ing TCE assignment, but other has no TCE assignment", null, tagsOfScenario, argumentsOfScenario);
+#line 167
+  this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 168
+    testRunner.Given("a patient has a match", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+                TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                            "A_1",
+                            "A_2",
+                            "B_1",
+                            "B_2",
+                            "DRB1_1",
+                            "DRB1_2",
+                            "DPB1_1",
+                            "DPB1_2"});
+                table13.AddRow(new string[] {
+                            "*01:01",
+                            "*66:01",
+                            "*57:01",
+                            "*41:01",
+                            "*13:XX",
+                            "*07:01",
+                            "*01:01",
+                            "*191:01/192:01"});
+#line 169
+    testRunner.And("the matching donor has the following HLA:", ((string)(null)), table13, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                            "A_1",
+                            "A_2",
+                            "B_1",
+                            "B_2",
+                            "DRB1_1",
+                            "DRB1_2",
+                            "DPB1_1",
+                            "DPB1_2"});
+                table14.AddRow(new string[] {
+                            "*01:01",
+                            "*66:01",
+                            "*57:01",
+                            "*41:01",
+                            "*13:XX",
+                            "*07:01",
+                            "*01:01",
+                            "*02:01"});
+#line 172
+    testRunner.And("the patient has the following HLA:", ((string)(null)), table14, "And ");
+#line hidden
+#line 175
+    testRunner.And("scoring is enabled at locus DPB1", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 176
+    testRunner.When("I run a 6/6 search", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 177
+    testRunner.Then("the match grade should be permissive mismatch at DPB1 at position 2", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/Atlas.MultipleAlleleCodeDictionary.Test.Integration/Repositories/LargeMacDictionary.csv
+++ b/Atlas.MultipleAlleleCodeDictionary.Test.Integration/Repositories/LargeMacDictionary.csv
@@ -6,8 +6,9 @@ Code,Code@type,HLA,HLA@type,IsGeneric,IsGeneric@type,PartitionKey,RowKey,Timesta
 #
 ABC,Edm.String,01/02,Edm.String,true,Edm.Boolean,3,ABC,2020-07-11T06:43:49.031Z
 DEF,Edm.String,02:01/03:01,Edm.String,false,Edm.Boolean,3,DEF,2020-07-11T06:43:49.031Z
+TCE,Edm.String,13:01/548:01,Edm.String,false,Edm.Boolean,3,TCE,2020-07-11T06:43:49.031Z
 XYZ,Edm.String,133/158,Edm.String,true,Edm.Boolean,3,XYZ,2020-07-11T06:43:49.031Z
-ZZZ,Edm.String,04N/133/158,Edm.String,true,Edm.Boolean,3,XYZ,2020-07-11T06:43:49.031Z
+ZZZ,Edm.String,04N/133/158,Edm.String,true,Edm.Boolean,3,ZZZ,2020-07-11T06:43:49.031Z
 FAKE,Edm.String,9999:9999,Edm.String,false,Edm.Boolean,4,FAKE,2020-07-11T06:43:49.031Z
 #
 # The rest of these records are used by the DonorUpdate Import smoke tests,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/625)
<!-- Reviewable:end -->
