### PR TITLE
fix: ATLAS-996: Use string value when stitching together distributed HMD serialised data

### DIFF
--- a/Atlas.HlaMetadataDictionary/InternalModels/MetadataTableRows/HlaMetadataTableRow.cs
+++ b/Atlas.HlaMetadataDictionary/InternalModels/MetadataTableRows/HlaMetadataTableRow.cs
@@ -85,7 +85,7 @@ namespace Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows
                     .Where(p => p != nameof(SerialisedHlaInfoType))
                     .OrderBy(p => p.Split(nameof(SerialisedHlaInfo))[1]))
                 {
-                    sb.Append(properties[splitSerialisedPropertyKey]);
+                    sb.Append(properties[splitSerialisedPropertyKey].StringValue);
                 }
 
                 SerialisedHlaInfo = sb.ToString();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/632)
<!-- Reviewable:end -->
