### PR TITLE
feature: #692: Allow match prediction to take place when either input…

### DIFF
--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MatchProbabilityTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MatchProbabilityTests.cs
@@ -47,7 +47,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
         }
 
         [Test]
-        public async Task CalculateMatchProbability_WhenIdenticalGenotypes_UnrepresentedInFrequencySet_ReturnsZeroPercent()
+        public async Task CalculateMatchProbability_WhenIdenticalUnambiguousGenotypes_UnrepresentedInFrequencySet_ReturnsOneHundredPercent()
         {
             var matchProbabilityInput = DefaultInputBuilder.Build();
 
@@ -55,19 +55,21 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
             {
                 DefaultHaplotypeFrequency1.WithDataAt(Locus.A, "68:24").With(h => h.Frequency, 0.00001m).Build()
             });
-
-            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability) null);
+            
+            var expectedZeroMismatchProbabilityPerLocus = new LociInfo<decimal?>(1).SetLocus(Locus.Dpb1, null);
+            var expectedOneMismatchProbabilityPerLocus = new LociInfo<decimal?>(0).SetLocus(Locus.Dpb1, null);
+            var expectedTwoMismatchProbabilityPerLocus = new LociInfo<decimal?>(0).SetLocus(Locus.Dpb1, null);
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
 
-            matchDetails.MatchProbabilities.ZeroMismatchProbability.Should().Be(null);
-            matchDetails.MatchProbabilities.OneMismatchProbability.Should().Be(null);
-            matchDetails.MatchProbabilities.TwoMismatchProbability.Should().Be(null);
-            matchDetails.ZeroMismatchProbabilityPerLocus.Should().Be(expectedMismatchProbabilityPerLocus);
-            matchDetails.OneMismatchProbabilityPerLocus.Should().Be(expectedMismatchProbabilityPerLocus);
-            matchDetails.TwoMismatchProbabilityPerLocus.Should().Be(expectedMismatchProbabilityPerLocus);
+            matchDetails.MatchProbabilities.ZeroMismatchProbability.Decimal.Should().Be(1m);
+            matchDetails.MatchProbabilities.OneMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.MatchProbabilities.TwoMismatchProbability.Decimal.Should().Be(0m);
+            matchDetails.ZeroMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedZeroMismatchProbabilityPerLocus);
+            matchDetails.OneMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedOneMismatchProbabilityPerLocus);
+            matchDetails.TwoMismatchProbabilityPerLocus.ToDecimals().Should().Be(expectedTwoMismatchProbabilityPerLocus);
         }
-
+        
         [Test]
         public async Task CalculateMatchProbability_WhenIdenticalGenotypes_RepresentedInFrequencySet_ReturnsOneHundredPercent()
         {

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MatchProbabilityTestsBase.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/MatchProbabilityTestsBase.cs
@@ -21,6 +21,8 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 {
     public class MatchProbabilityTestsBase
     {
+        protected readonly FrequencySetMetadata GlobalHfSetMetadata = new FrequencySetMetadata { EthnicityCode = null, RegistryCode = null };
+
         protected IMatchProbabilityService MatchProbabilityService;
         protected IHaplotypeFrequencyService ImportService;
 
@@ -46,8 +48,8 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
             string nomenclatureVersion = HlaNomenclatureVersion,
             ImportTypingCategory typingCategory = ImportTypingCategory.LargeGGroup)
         {
-            var registry = registryCode == null ? null : new[] {registryCode};
-            var ethnicity = ethnicityCode == null ? null : new[] {ethnicityCode};
+            var registry = registryCode == null ? null : new[] { registryCode };
+            var ethnicity = ethnicityCode == null ? null : new[] { ethnicityCode };
 
             using var file = FrequencySetFileBuilder
                 .New(haplotypes, registry, ethnicity, nomenclatureVersion: nomenclatureVersion, typingCategory: typingCategory)
@@ -76,7 +78,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
         protected static Builder<SingleDonorMatchProbabilityInput> DefaultInputBuilder => SingleDonorMatchProbabilityInputBuilder.Default
             .WithPatientHla(DefaultUnambiguousAllelesBuilder.Build())
             .WithDonorHla(DefaultUnambiguousAllelesBuilder.Build())
-            .WithDonorMetadata(new FrequencySetMetadata {EthnicityCode = DefaultEthnicityCode, RegistryCode = DefaultRegistryCode})
-            .WithPatientMetadata(new FrequencySetMetadata {EthnicityCode = DefaultEthnicityCode, RegistryCode = DefaultRegistryCode});
+            .WithDonorMetadata(new FrequencySetMetadata { EthnicityCode = DefaultEthnicityCode, RegistryCode = DefaultRegistryCode })
+            .WithPatientMetadata(new FrequencySetMetadata { EthnicityCode = DefaultEthnicityCode, RegistryCode = DefaultRegistryCode });
     }
 }

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/UnambiguousGenotypeTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/UnambiguousGenotypeTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Reflection;
+using System.Threading.Tasks;
+using Atlas.Common.GeneticData;
+using Atlas.Common.GeneticData.PhenotypeInfo;
+using Atlas.Common.Test.SharedTestHelpers;
+using Atlas.Common.Test.SharedTestHelpers.Builders;
+using Atlas.MatchPrediction.Services.HaplotypeFrequencies;
+using Atlas.MatchPrediction.Services.HaplotypeFrequencies.Import;
+using Atlas.MatchPrediction.Test.Integration.TestHelpers.Builders.FrequencySetFile;
+using Atlas.MatchPrediction.Test.TestHelpers.Builders.MatchProbabilityInputs;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPrediction.MatchProbability
+{
+    public class UnambiguousGenotypeTests : MatchProbabilityTestsBase
+    {
+        // This genotype has been specifically selected to be unrepresented in the global HF set.
+        private readonly PhenotypeInfo<string> unambiguousUnrepresentedGenotype = new PhenotypeInfoBuilder<string>()
+            .WithDataAt(Locus.A, LocusPosition.One, "01:01")
+            .WithDataAt(Locus.A, LocusPosition.Two, "23:01")
+            .WithDataAt(Locus.B, LocusPosition.One, "44:03")
+            .WithDataAt(Locus.B, LocusPosition.Two, "57:01")
+            .WithDataAt(Locus.C, LocusPosition.One, "04:09N")
+            .WithDataAt(Locus.C, LocusPosition.Two, "06:02")
+            .WithDataAt(Locus.Dqb1, LocusPosition.One, "03:01")
+            .WithDataAt(Locus.Dqb1, LocusPosition.Two, "04:01")
+            .WithDataAt(Locus.Drb1, LocusPosition.One, "08:07")
+            .WithDataAt(Locus.Drb1, LocusPosition.Two, "11:04")
+            .Build();
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            await TestStackTraceHelper.CatchAndRethrowWithStackTraceInExceptionMessage_Async(async () => { await ImportHaplotypeFrequencies(); });
+        }
+
+        [Test]
+        public async Task
+            CalculateMatchProbability_WhenPatientIsUnambiguousByPGroup_AndUnrepresentedInHaplotypeFrequencySet_DoesNotMarkPatientAsUnrepresented()
+        {
+            var donorHla = new PhenotypeInfoBuilder<string>()
+                .WithDataAt(Locus.A, LocusPosition.One, "01:XX")
+                .WithDataAt(Locus.A, LocusPosition.Two, "23:XX")
+                .WithDataAt(Locus.B, LocusPosition.One, "44:XX")
+                .WithDataAt(Locus.B, LocusPosition.Two, "57:XX")
+                .WithDataAt(Locus.C, LocusPosition.One, "04:XX")
+                .WithDataAt(Locus.C, LocusPosition.Two, "06:XX")
+                .WithDataAt(Locus.Dqb1, LocusPosition.One, "03:XX")
+                .WithDataAt(Locus.Dqb1, LocusPosition.Two, "04:XX")
+                .WithDataAt(Locus.Drb1, LocusPosition.One, "08:XX")
+                .WithDataAt(Locus.Drb1, LocusPosition.Two, "11:XX")
+                .Build();
+
+            var matchProbabilityInput = DefaultInputBuilder
+                .WithPatientHla(unambiguousUnrepresentedGenotype)
+                .WithPatientMetadata(GlobalHfSetMetadata)
+                .WithDonorHla(donorHla)
+                .WithDonorMetadata(GlobalHfSetMetadata)
+                .Build();
+
+            var matchProbability = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
+
+            matchProbability.IsPatientPhenotypeUnrepresented.Should().BeFalse();
+            matchProbability.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(0);
+            matchProbability.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(0);
+            matchProbability.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(32);
+        }
+        [Test]
+        public async Task
+            CalculateMatchProbability_WhenDonorIsUnambiguousByPGroup_AndUnrepresentedInHaplotypeFrequencySet_DoesNotMarkDonorAsUnrepresented()
+        {
+            var patientHla = new PhenotypeInfoBuilder<string>()
+                .WithDataAt(Locus.A, LocusPosition.One, "01:XX")
+                .WithDataAt(Locus.A, LocusPosition.Two, "23:XX")
+                .WithDataAt(Locus.B, LocusPosition.One, "44:XX")
+                .WithDataAt(Locus.B, LocusPosition.Two, "57:XX")
+                .WithDataAt(Locus.C, LocusPosition.One, "04:XX")
+                .WithDataAt(Locus.C, LocusPosition.Two, "06:XX")
+                .WithDataAt(Locus.Dqb1, LocusPosition.One, "03:XX")
+                .WithDataAt(Locus.Dqb1, LocusPosition.Two, "04:XX")
+                .WithDataAt(Locus.Drb1, LocusPosition.One, "08:XX")
+                .WithDataAt(Locus.Drb1, LocusPosition.Two, "11:XX")
+                .Build();
+
+            var matchProbabilityInput = DefaultInputBuilder
+                .WithPatientHla(patientHla)
+                .WithPatientMetadata(GlobalHfSetMetadata)
+                .WithDonorHla(unambiguousUnrepresentedGenotype)
+                .WithDonorMetadata(GlobalHfSetMetadata)
+                .Build();
+
+            var matchProbability = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
+
+            matchProbability.IsDonorPhenotypeUnrepresented.Should().BeFalse();
+            matchProbability.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(0);
+            matchProbability.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(0);
+            matchProbability.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(32);
+        }
+        
+        [Test]
+        public async Task
+            CalculateMatchProbability_WhenDonorAndPatientAreBothUnambiguous_AndUnrepresented_DoesNotMarkEitherAsUnrepresented_AndReturnsCertainProbability()
+        {
+            var matchProbabilityInput = DefaultInputBuilder
+                .WithPatientHla(unambiguousUnrepresentedGenotype)
+                .WithPatientMetadata(GlobalHfSetMetadata)
+                .WithDonorHla(unambiguousUnrepresentedGenotype)
+                .WithDonorMetadata(GlobalHfSetMetadata)
+                .Build();
+
+            var matchProbability = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
+
+            matchProbability.IsDonorPhenotypeUnrepresented.Should().BeFalse();
+            matchProbability.IsPatientPhenotypeUnrepresented.Should().BeFalse();
+            matchProbability.MatchProbabilities.ZeroMismatchProbability.Percentage.Should().Be(100);
+            matchProbability.MatchProbabilities.OneMismatchProbability.Percentage.Should().Be(0);
+            matchProbability.MatchProbabilities.TwoMismatchProbability.Percentage.Should().Be(0);
+        }
+        
+        private static async Task ImportHaplotypeFrequencies()
+        {
+            var importer = DependencyInjection.DependencyInjection.Provider.GetService<IHaplotypeFrequencyService>();
+
+            var filePath = $"Atlas.MatchPrediction.Test.Integration.Resources.HaplotypeFrequencySets.global.json";
+
+            await using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(filePath))
+            using (var file = FrequencySetFileBuilder.FileWithoutContents()
+                .WithHaplotypeFrequencyFileStream(stream)
+                .Build()
+            )
+            {
+                await importer.ImportFrequencySet(file, new FrequencySetImportBehaviour{ ShouldBypassHlaValidation = true});
+            }
+        }
+    }
+}

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/UnrepresentedLociTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/MatchPrediction/MatchProbability/UnrepresentedLociTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Atlas.Common.GeneticData;
 using Atlas.Common.GeneticData.PhenotypeInfo;
 using Atlas.Common.Utils.Models;
 using Atlas.MatchPrediction.Data.Models;
@@ -11,12 +12,18 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 {
     public class UnrepresentedLociTests : MatchProbabilityTestsBase
     {
+        // the default "ambiguous alleles builder" is not actually ambiguous with respect to g-groups
+        // - to show up as unrepresented, there must be some ambiguity at the g-group level in the input genotype
+        private PhenotypeInfo<string> ambiguousGenotype = DefaultAmbiguousAllelesBuilder
+            .WithDataAt(Locus.A, LocusPosition.One, "01:XX")
+            .Build();
+
         [Test]
         public async Task CalculateMatchProbability_WhenUnrepresentedPatientAndDonor_ReturnsNullProbabilityAndPatientAndDonorUnrepresentedFlagsTrue()
         {
             var matchProbabilityInput = DefaultInputBuilder
-                .WithDonorHla(DefaultAmbiguousAllelesBuilder.Build())
-                .WithPatientHla(DefaultAmbiguousAllelesBuilder.Build())
+                .WithDonorHla(ambiguousGenotype)
+                .WithPatientHla(ambiguousGenotype)
                 .Build();
 
             var possibleHaplotypes = new List<HaplotypeFrequency>
@@ -27,7 +34,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             await ImportFrequencies(possibleHaplotypes, null, null);
 
-            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability) null);
+            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability)null);
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
             var roundedMatchDetails = matchDetails.Round(4);
@@ -45,7 +52,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
         [Test]
         public async Task CalculateMatchProbability_WhenUnrepresentedPatient_ReturnsNullProbabilityAndPatientUnrepresentedFlagTrue()
         {
-            var matchProbabilityInput = DefaultInputBuilder.WithPatientHla(DefaultAmbiguousAllelesBuilder.Build()).Build();
+            var matchProbabilityInput = DefaultInputBuilder.WithPatientHla(ambiguousGenotype).Build();
 
             var possibleHaplotypes = new List<HaplotypeFrequency>
             {
@@ -55,7 +62,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             await ImportFrequencies(possibleHaplotypes, null, null);
 
-            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability) null);
+            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability)null);
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
             var roundedMatchDetails = matchDetails.Round(4);
@@ -73,7 +80,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
         [Test]
         public async Task CalculateMatchProbability_WhenUnrepresentedDonor_ReturnsNullProbabilityAndDonorUnrepresentedFlagTrue()
         {
-            var matchProbabilityInput = DefaultInputBuilder.WithDonorHla(DefaultAmbiguousAllelesBuilder.Build()).Build();
+            var matchProbabilityInput = DefaultInputBuilder.WithDonorHla(ambiguousGenotype).Build();
 
             var possibleHaplotypes = new List<HaplotypeFrequency>
             {
@@ -83,7 +90,7 @@ namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.MatchPredictio
 
             await ImportFrequencies(possibleHaplotypes, null, null);
 
-            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability) null);
+            var expectedMismatchProbabilityPerLocus = new LociInfo<Probability>((Probability)null);
 
             var matchDetails = await MatchProbabilityService.CalculateMatchProbability(matchProbabilityInput);
             var roundedMatchDetails = matchDetails.Round(4);

--- a/Atlas.MatchPrediction/Services/CompressedPhenotypeExpansion/CompressedPhenotypeExpander.cs
+++ b/Atlas.MatchPrediction/Services/CompressedPhenotypeExpansion/CompressedPhenotypeExpander.cs
@@ -85,6 +85,21 @@ namespace Atlas.MatchPrediction.Services.CompressedPhenotypeExpansion
 
             var groupsPerLocus = groupsPerPosition.Map(CombineSetsAtLoci);
 
+            var isUnambiguousAtSelectedLoci = allowedLoci.All(l =>
+            {
+                var groupsAtLocus = groupsPerPosition.SmallGGroup.GetLocus(l);
+                return groupsAtLocus.Position1?.Count == 1 && groupsAtLocus.Position2?.Count == 1;
+            });
+            
+            if (isUnambiguousAtSelectedLoci)
+            {
+                return new HashSet<PhenotypeInfo<HlaAtKnownTypingCategory>>
+                {
+                    groupsPerPosition.SmallGGroup.Map((_, __, v) =>
+                        v == null ? null : new HlaAtKnownTypingCategory(v.Single(), HaplotypeTypingCategory.SmallGGroup))
+                };
+            }
+
             var allowedHaplotypes = GetAllowedHaplotypes(allowedLoci, input.AllHaplotypes, groupsPerLocus);
 
             var allowedHaplotypesExcludingLoci = new HashSet<LociInfo<HlaAtKnownTypingCategory>>(allowedHaplotypes.Select(h =>

--- a/Atlas.MatchPrediction/Services/MatchProbability/MatchProbabilityService.cs
+++ b/Atlas.MatchPrediction/Services/MatchProbability/MatchProbabilityService.cs
@@ -335,10 +335,19 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
             {
                 var genotypeLikelihoods = new List<KeyValuePair<StringGenotype, decimal>>();
 
-                foreach (var genotype in genotypes)
+                // If there is no ambiguity for an input genotype, we do not need to use haplotype frequencies to work out the likelihood of said genotype - it is already guaranteed! 
+                if (genotypes.Count == 1)
                 {
-                    genotypeLikelihoods.Add(await CalculateLikelihood(genotype, frequencySet, allowedLoci));
+                    genotypeLikelihoods.Add(new KeyValuePair<StringGenotype, decimal>(genotypes.Single(), 1));
                 }
+                else
+                {
+                    foreach (var genotype in genotypes)
+                    {
+                        genotypeLikelihoods.Add(await CalculateLikelihood(genotype, frequencySet, allowedLoci));
+                    }
+                }
+
                 return genotypeLikelihoods.ToDictionary();
             }
         }


### PR DESCRIPTION
… genotype is unrepresented, but also unambiguous with respect to g-groups

Technically P-Groups are used to calculate matches - however we've opted to use g-groups at this stage, to avoid losing information about null alleles (which have no P-group, but do have a g-group)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/694)
<!-- Reviewable:end -->
