### PR TITLE
feature: #716: When scoring, consider an empty string "untyped" for a…

### DIFF
--- a/Atlas.MatchingAlgorithm/Services/Search/Scoring/DonorScoringService.cs
+++ b/Atlas.MatchingAlgorithm/Services/Search/Scoring/DonorScoringService.cs
@@ -136,10 +136,10 @@ namespace Atlas.MatchingAlgorithm.Services.Search.Scoring
         protected async Task<PhenotypeInfo<IHlaScoringMetadata>> GetHlaScoringMetadata(PhenotypeInfo<string> hlaNames, IEnumerable<Locus> lociToScore)
         {
             return await hlaNames.MapAsync(
-                async (locus, position, hla) =>
+                async (locus, _, hla) =>
                 {
                     // do not perform lookup for an untyped locus or a locus that is not to be scored
-                    if (hla == null || !lociToScore.Contains(locus))
+                    if (hla.IsNullOrEmpty() || !lociToScore.Contains(locus))
                     {
                         return default;
                     }


### PR DESCRIPTION
… phenotype, and do not attempt HMD lookup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/717)
<!-- Reviewable:end -->
