### PR TITLE
chore: Peek searchable donor update topic by Atlas donor ID.

### DIFF
--- a/Atlas.Functions.PublicApi.Test.Manual/Functions/DonorUpdateMessageFunctions.cs
+++ b/Atlas.Functions.PublicApi.Test.Manual/Functions/DonorUpdateMessageFunctions.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using Atlas.Functions.PublicApi.Test.Manual.Helpers;
+using Atlas.Functions.PublicApi.Test.Manual.Models;
+using Atlas.Functions.PublicApi.Test.Manual.Services;
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace Atlas.Functions.PublicApi.Test.Manual.Functions
+{
+    public class DonorUpdateMessageFunctions
+    {
+        private readonly ISearchableDonorUpdatesPeeker searchableDonorUpdatesPeeker;
+
+        public DonorUpdateMessageFunctions(ISearchableDonorUpdatesPeeker searchableDonorUpdatesPeeker)
+        {
+            this.searchableDonorUpdatesPeeker = searchableDonorUpdatesPeeker;
+        }
+
+        [FunctionName(nameof(FilterSearchableDonorUpdatesByAtlasDonorId))]
+        public async Task<IActionResult> FilterSearchableDonorUpdatesByAtlasDonorId(
+            [HttpTrigger(AuthorizationLevel.Function, "post")]
+            [RequestBodyType(typeof(PeekByAtlasDonorIdRequest), nameof(PeekByAtlasDonorIdRequest))]
+            HttpRequest request)
+        {
+            var peekRequest = await request.DeserialiseRequestBody<PeekByAtlasDonorIdRequest>();
+
+            var resultsNotifications = await searchableDonorUpdatesPeeker.GetMessagesByAtlasDonorId(peekRequest);
+
+            return new JsonResult(resultsNotifications);
+        }
+    }
+}

--- a/Atlas.Functions.PublicApi.Test.Manual/Functions/SearchRelatedMessageFunctions.cs
+++ b/Atlas.Functions.PublicApi.Test.Manual/Functions/SearchRelatedMessageFunctions.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using System.Threading.Tasks;
+using Atlas.Functions.PublicApi.Test.Manual.Helpers;
 using Atlas.Functions.PublicApi.Test.Manual.Models;
 using Atlas.Functions.PublicApi.Test.Manual.Services;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
 
 namespace Atlas.Functions.PublicApi.Test.Manual.Functions
 {
@@ -30,7 +29,7 @@ namespace Atlas.Functions.PublicApi.Test.Manual.Functions
             [RequestBodyType(typeof(PeekRequest), nameof(PeekRequest))]
             HttpRequest request)
         {
-            var peekRequest = await DeserialiseRequestBody<PeekRequest>(request);
+            var peekRequest = await request.DeserialiseRequestBody<PeekRequest>();
 
             var ids = await matchingRequestsPeeker.GetIdsOfDeadLetteredMatchingRequests(peekRequest);
 
@@ -43,7 +42,7 @@ namespace Atlas.Functions.PublicApi.Test.Manual.Functions
             [RequestBodyType(typeof(PeekRequest), nameof(PeekRequest))]
             HttpRequest request)
         {
-            var peekRequest = await DeserialiseRequestBody<PeekRequest>(request);
+            var peekRequest = await request.DeserialiseRequestBody<PeekRequest>();
 
             var ids = await notificationsPeeker.GetIdsOfFailedSearches(peekRequest);
 
@@ -56,7 +55,7 @@ namespace Atlas.Functions.PublicApi.Test.Manual.Functions
             [RequestBodyType(typeof(PeekRequest), nameof(PeekRequest))]
             HttpRequest request)
         {
-            var peekRequest = await DeserialiseRequestBody<PeekRequest>(request);
+            var peekRequest = await request.DeserialiseRequestBody<PeekRequest>();
 
             var resultsNotifications = await notificationsPeeker.GetSearchResultsNotifications(peekRequest);
 
@@ -69,17 +68,11 @@ namespace Atlas.Functions.PublicApi.Test.Manual.Functions
             [RequestBodyType(typeof(PeekBySearchRequestIdRequest), nameof(PeekBySearchRequestIdRequest))]
             HttpRequest request)
         {
-            var peekRequest = await DeserialiseRequestBody<PeekBySearchRequestIdRequest>(request);
+            var peekRequest = await request.DeserialiseRequestBody<PeekBySearchRequestIdRequest>();
 
             var resultsNotifications = await notificationsPeeker.GetNotificationsBySearchRequestId(peekRequest);
 
             return new JsonResult(resultsNotifications);
-        }
-
-        private static async Task<T> DeserialiseRequestBody<T>(HttpRequest request)
-        {
-            return JsonConvert.DeserializeObject<T>(
-                await new StreamReader(request.Body).ReadToEndAsync());
         }
     }
 }

--- a/Atlas.Functions.PublicApi.Test.Manual/Helpers/RequestExtension.cs
+++ b/Atlas.Functions.PublicApi.Test.Manual/Helpers/RequestExtension.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace Atlas.Functions.PublicApi.Test.Manual.Helpers
+{
+    internal static class RequestExtension
+    {
+        public static async Task<T> DeserialiseRequestBody<T>(this HttpRequest request)
+        {
+            return JsonConvert.DeserializeObject<T>(
+                await new StreamReader(request.Body).ReadToEndAsync());
+        }
+    }
+}

--- a/Atlas.Functions.PublicApi.Test.Manual/Models/PeekRequest.cs
+++ b/Atlas.Functions.PublicApi.Test.Manual/Models/PeekRequest.cs
@@ -10,4 +10,9 @@
     {
         public string SearchRequestId { get; set; }
     }
+
+    public class PeekByAtlasDonorIdRequest : PeekRequest
+    {
+        public int AtlasDonorId { get; set; }
+    }
 }

--- a/Atlas.Functions.PublicApi.Test.Manual/Services/SearchableDonorUpdatesPeeker.cs
+++ b/Atlas.Functions.PublicApi.Test.Manual/Services/SearchableDonorUpdatesPeeker.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Atlas.Common.ServiceBus.Models;
+using Atlas.Functions.PublicApi.Test.Manual.Models;
+using Atlas.Functions.PublicApi.Test.Manual.Services.ServiceBus;
+using Atlas.MatchingAlgorithm.Client.Models.Donors;
+
+namespace Atlas.Functions.PublicApi.Test.Manual.Services
+{
+    public interface ISearchableDonorUpdatesPeeker
+    {
+        Task<IEnumerable<ServiceBusMessage<SearchableDonorUpdate>>> GetMessagesByAtlasDonorId(PeekByAtlasDonorIdRequest peekRequest);
+    }
+
+    internal class SearchableDonorUpdatesPeeker : ISearchableDonorUpdatesPeeker
+    {
+        private readonly IMessagesPeeker<SearchableDonorUpdate> messagesReceiver;
+
+        public SearchableDonorUpdatesPeeker(IMessagesPeeker<SearchableDonorUpdate> messagesReceiver)
+        {
+            this.messagesReceiver = messagesReceiver;
+        }
+
+        public async Task<IEnumerable<ServiceBusMessage<SearchableDonorUpdate>>> GetMessagesByAtlasDonorId(PeekByAtlasDonorIdRequest peekRequest)
+        {
+            var notifications = await messagesReceiver.Peek(peekRequest);
+
+            return notifications.Where(n => n.DeserializedBody.DonorId == peekRequest.AtlasDonorId);
+        }
+    }
+}

--- a/Atlas.Functions.PublicApi.Test.Manual/Settings/DonorManagementSettings.cs
+++ b/Atlas.Functions.PublicApi.Test.Manual/Settings/DonorManagementSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace Atlas.Functions.PublicApi.Test.Manual.Settings
+{
+    internal class DonorManagementSettings
+    {
+        public string Topic { get; set; }
+        public string Subscription { get; set; }
+    }
+}

--- a/Atlas.Functions.PublicApi.Test.Manual/local.settings.template.json
+++ b/Atlas.Functions.PublicApi.Test.Manual/local.settings.template.json
@@ -7,6 +7,8 @@
 
     "Matching:RequestsTopic": "matching-requests",
     "Matching:RequestsSubscription": "audit",
+    "Matching:DonorManagement:Topic": "updated-searchable-donors",
+    "Matching:DonorManagement:Subscription": "audit",
 
     "Search:ResultsTopic": "search-results-ready",
     "Search:ResultsSubscription": "audit"


### PR DESCRIPTION
Change to non-production, manual testing/debug project on Atlas, allows dev to filter audit sub of topic by atlas donor ID

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anthony-nolan/atlas/815)
<!-- Reviewable:end -->
