### PR TITLE
fix: #875: Update test pipeline to support multiple orgs

### DIFF
--- a/terraform/system-tests/main.tf
+++ b/terraform/system-tests/main.tf
@@ -19,8 +19,9 @@ provider "azurerm" {
 
 locals {
   repository_name     = "Atlas"
-  location            = "uksouth"
+  location            = var.AZURE_LOCATION
   min_tls_version     = "1.0"
+  name_prefix         = var.NAME_PREFIX
   resource_group_name = "ATLAS-SYSTEM-TEST-RESOURCE-GROUP"
   common_tags = {
     controlled_by_terraform = true

--- a/terraform/system-tests/sql_server.tf
+++ b/terraform/system-tests/sql_server.tf
@@ -1,5 +1,5 @@
 resource "azurerm_mssql_server" "atlas_sql_server" {
-  name                         = lower("ATLAS-SYSTEM-TEST-SQL-SERVER")
+  name                         = "${lower(replace(local.name_prefix, "/\\W/", ""))}-atlas-system-test-sql-server"
   resource_group_name          = azurerm_resource_group.atlas_system_tests_resource_group.name
   location                     = local.location
   tags                         = local.common_tags

--- a/terraform/system-tests/storage.tf
+++ b/terraform/system-tests/storage.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "system_test_storage" {
-  name                     = lower("AtlasSystemTestStorage")
+  name                     = "${lower(replace(local.name_prefix, "/\\W/", ""))}systemteststorage"
   resource_group_name      = azurerm_resource_group.atlas_system_tests_resource_group.name
   min_tls_version          = "TLS1_0"
   location                 = local.location

--- a/terraform/system-tests/variables.tf
+++ b/terraform/system-tests/variables.tf
@@ -1,3 +1,9 @@
+variable "AZURE_LOCATION" {
+  type = string
+  description = "Azure region resources are deployed to."
+  default = "uksouth"
+}
+
 variable "AZURE_SUBSCRIPTION_ID" {
   type        = string
   description = "ID of the Azure subscription into which the system will be deployed."
@@ -26,3 +32,12 @@ variable "DATABASE_SERVER_AZUREAD_ADMINISTRATOR_TENANTID" {
   type = string
   description = "ID of Tenant where admin access AD group resides."
 }
+
+variable "NAME_PREFIX" {
+  type        = string
+  description = "Prepended to resources that require globally unique names (storage accounts, etc)."
+  default	  = "Atlas"
+}
+
+
+

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -133,7 +133,7 @@ jobs:
     displayName: 'Nuget Restore'
     inputs:
       command: 'restore'
-      vstsFeed: '47b810d9-ad1c-410b-b5e5-45a100bcf88a'
+      feedsToUse: 'select'
 
   - task: bendayconsulting.build-task.setjsonconfigconnectionstring.setjsonconfigconnectionstring@1
     displayName: 'Update connection string ''DonorSql'''

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -52,6 +52,9 @@ jobs:
       env:
         ARM_ACCESS_KEY: $(ARM_ACCESS_KEY)
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+        ARM_CLIENT_ID: $(ARM_CLIENT_ID)
+        TF_VAR_DATABASE_SERVER_ADMIN_LOGIN_PASSWORD: $(TF_VAR_DATABASE_SERVER_ADMIN_LOGIN_PASSWORD)
+
     - task: Powershell@2
       name: OutputTFVars
       env:


### PR DESCRIPTION
Adding optional terraform AZURE_LOCATION variable to support Azure region selection
Using dynamic SQL and storage account names to support unique names across deployments
Removing Anthony Nolan VSTS feed id from test-pipeline.xml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/873)
<!-- Reviewable:end -->
