### PR TITLE
fix: #875: updating system-test sql name

### DIFF
--- a/terraform/system-tests/sql_server.tf
+++ b/terraform/system-tests/sql_server.tf
@@ -1,5 +1,5 @@
 resource "azurerm_mssql_server" "atlas_sql_server" {
-  name                         = "${lower(replace(local.name_prefix, "/\\W/", ""))}-atlas-system-test-sql-server"
+  name                         = "${lower(replace(local.name_prefix, "/\\W/", ""))}-system-test-sql-server"
   resource_group_name          = azurerm_resource_group.atlas_system_tests_resource_group.name
   location                     = local.location
   tags                         = local.common_tags


### PR DESCRIPTION
removed -atlas from system test sql server name.  Validated Terraform runs successfully against https://dev.azure.com/anthony-nolan-nova/Atlas/_build/results?buildId=31540&view=results

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/888)
<!-- Reviewable:end -->
