### PR TITLE
fix: Fix build by specifying dotnet-ef to install.

### DIFF
--- a/build-pipeline.yml
+++ b/build-pipeline.yml
@@ -20,7 +20,7 @@ jobs:
         inputs:
           command: 'custom'
           custom: 'tool'
-          arguments: 'install dotnet-ef --global --ignore-failed-sources'
+          arguments: 'install dotnet-ef --global --ignore-failed-sources --version "6.0.*"'
       - task: DotNetCoreCLI@2
         displayName: 'Restore'
         inputs:


### PR DESCRIPTION
Atlas build failing today at `install dotnet-ef` step:
Package dotnet-ef 8.0.0 is not compatible with net6.0 (.NETCoreApp,Version=v6.0) / any. Package dotnet-ef 8.0.0 supports: net8.0 (.NETCoreApp,Version=v8.0) / any
The tool package could not be restored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1124)
<!-- Reviewable:end -->
