### PR TITLE
bug: #1041: setting message Id when publish search results

### DIFF
--- a/Atlas.MatchingAlgorithm/Clients/ServiceBus/SearchServiceBusClient.cs
+++ b/Atlas.MatchingAlgorithm/Clients/ServiceBus/SearchServiceBusClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using Atlas.Client.Models.Search.Results.Matching;
@@ -56,6 +57,10 @@ namespace Atlas.MatchingAlgorithm.Clients.ServiceBus
                     {nameof(MatchingResultsNotification.ElapsedTime), matchingResultsNotification.ElapsedTime},
                 }
             };
+
+            // That should help in investigation of #962. When matching-results-ready queue get two messages for same search id,
+            // the fact that messages have the same message id will prove that it happens because client auto retry functionality
+            message.MessageId = Guid.NewGuid().ToString();
 
             var client = new TopicClient(connectionString, resultsNotificationTopicName);
             await client.SendAsync(message);


### PR DESCRIPTION
For diagnostic purpose. To confirm that several messages with same search Id in matching-results-ready caused by client's retries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1215)
<!-- Reviewable:end -->
