### PR TITLE
Cbt 1476 send matching algorithm core scoring started event

### DIFF
--- a/Atlas.MatchingAlgorithm.Api/Startup.cs
+++ b/Atlas.MatchingAlgorithm.Api/Startup.cs
@@ -79,7 +79,7 @@ namespace Atlas.MatchingAlgorithm.Api
                 ConnectionStringReader("SqlA"),
                 ConnectionStringReader("SqlB"),
                 ConnectionStringReader("DonorSql"));
-            
+
             services.RegisterDataRefresh(
                 OptionsReaderFor<AzureAuthenticationSettings>(),
                 OptionsReaderFor<AzureDatabaseManagementSettings>(),
@@ -95,7 +95,7 @@ namespace Atlas.MatchingAlgorithm.Api
                 ConnectionStringReader("SqlA"),
                 ConnectionStringReader("SqlB"),
                 ConnectionStringReader("DonorSql"));
-            
+
             services.RegisterDonorManagement(
                 OptionsReaderFor<ApplicationInsightsSettings>(),
                 OptionsReaderFor<AzureStorageSettings>(),
@@ -150,6 +150,7 @@ namespace Atlas.MatchingAlgorithm.Api
             services.RegisterAsOptions<MatchingConfigurationSettings>("MatchingConfiguration");
             services.RegisterAsOptions<MessagingServiceBusSettings>("MessagingServiceBus");
             services.RegisterAsOptions<NotificationsServiceBusSettings>("NotificationsServiceBus");
+            services.RegisterAsOptions<SearchTrackingServiceBusSettings>("SearchTrackingServiceBus");
         }
     }
 }

--- a/Atlas.MatchingAlgorithm.Test.Validation/appsettings.json
+++ b/Atlas.MatchingAlgorithm.Test.Validation/appsettings.json
@@ -86,5 +86,9 @@
   },
   "AzureAppConfiguration": {
     "ConnectionString": "override-this"
+  },
+  "SearchTrackingServiceBus": {
+    "ConnectionString": "override-this",
+    "SearchTrackingTopic": "search-tracking-events"
   }
 }

--- a/Atlas.MatchingAlgorithm.Test/Services/Search/Scoring/MatchScoringServiceTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Services/Search/Scoring/MatchScoringServiceTests.cs
@@ -24,6 +24,7 @@ using Atlas.Common.Public.Models.GeneticData;
 using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo;
 using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.TransferModels;
 using Atlas.MatchingAlgorithm.ApplicationInsights.ContextAwareLogging;
+using Atlas.MatchingAlgorithm.Services.Search;
 using Atlas.MatchingAlgorithm.Services.Search.Scoring.AntigenMatching;
 
 namespace Atlas.MatchingAlgorithm.Test.Services.Search.Scoring
@@ -38,6 +39,7 @@ namespace Atlas.MatchingAlgorithm.Test.Services.Search.Scoring
         private IRankingService rankingService;
         private IMatchScoreCalculator matchScoreCalculator;
         private IScoreResultAggregator scoreResultAggregator;
+        private IMatchingAlgorithmSearchTrackingDispatcher matchingAlgorithmSearchTrackingDispatcher;
 
         private IMatchScoringService scoringService;
 
@@ -53,16 +55,17 @@ namespace Atlas.MatchingAlgorithm.Test.Services.Search.Scoring
             matchScoreCalculator = Substitute.For<IMatchScoreCalculator>();
             scoreResultAggregator = Substitute.For<IScoreResultAggregator>();
             var hlaVersionAccessor = Substitute.For<IActiveHlaNomenclatureVersionAccessor>();
+            matchingAlgorithmSearchTrackingDispatcher = Substitute.For<IMatchingAlgorithmSearchTrackingDispatcher>();
 
             rankingService.RankSearchResults(Arg.Any<IEnumerable<MatchAndScoreResult>>())
                 .Returns(callInfo => (IEnumerable<MatchAndScoreResult>) callInfo.Args().First());
-            
+
             gradingService.Score(default, default, default)
                 .ReturnsForAnyArgs(new LociInfo<LocusScoreResult<MatchGrade>>(new LocusScoreResult<MatchGrade>(MatchGrade.Mismatch)));
-            
+
             confidenceService.Score(default, default, default)
                 .ReturnsForAnyArgs(new LociInfo<LocusScoreResult<MatchConfidence>>(new LocusScoreResult<MatchConfidence>(MatchConfidence.Mismatch)));
-            
+
             antigenMatchingService.Score(default, default, default)
                 .ReturnsForAnyArgs(new LociInfo<LocusScoreResult<bool?>>(new LocusScoreResult<bool?>(false)));
 
@@ -79,7 +82,8 @@ namespace Atlas.MatchingAlgorithm.Test.Services.Search.Scoring
                 scoreResultAggregator,
                 Substitute.For<IMatchingAlgorithmSearchLogger>(),
                 Substitute.For<IDpb1TceGroupMatchCalculator>(),
-                Substitute.For<ILogger>()
+                Substitute.For<ILogger>(),
+                matchingAlgorithmSearchTrackingDispatcher
             );
         }
 

--- a/Atlas.MatchingAlgorithm/Services/Search/Matching/MatchingService.cs
+++ b/Atlas.MatchingAlgorithm/Services/Search/Matching/MatchingService.cs
@@ -11,7 +11,6 @@ using Atlas.MatchingAlgorithm.Data.Repositories.DonorRetrieval;
 using Atlas.MatchingAlgorithm.Models;
 using Atlas.MatchingAlgorithm.Services.ConfigurationProviders.TransientSqlDatabase.RepositoryFactories;
 using Atlas.MatchingAlgorithm.Settings;
-using Atlas.SearchTracking.Common.Enums;
 using Dasync.Collections;
 
 namespace Atlas.MatchingAlgorithm.Services.Search.Matching
@@ -28,7 +27,6 @@ namespace Atlas.MatchingAlgorithm.Services.Search.Matching
         private readonly IMatchFilteringService matchFilteringService;
         private readonly ILogger searchLogger;
         private readonly MatchingConfigurationSettings matchingConfigurationSettings;
-        private readonly IMatchingAlgorithmSearchTrackingDispatcher matchingAlgorithmSearchTrackingDispatcher;
 
         public MatchingService(
             IDonorMatchingService donorMatchingService,
@@ -45,7 +43,6 @@ namespace Atlas.MatchingAlgorithm.Services.Search.Matching
             this.matchFilteringService = matchFilteringService;
             this.searchLogger = searchLogger;
             this.matchingConfigurationSettings = matchingConfigurationSettings;
-            this.matchingAlgorithmSearchTrackingDispatcher = matchingAlgorithmSearchTrackingDispatcher;
         }
 
         public async IAsyncEnumerable<MatchResult> GetMatches(MatchCriteria criteria, DateTimeOffset? cutOffDate)
@@ -59,9 +56,6 @@ namespace Atlas.MatchingAlgorithm.Services.Search.Matching
                     );
                 }
 
-                await matchingAlgorithmSearchTrackingDispatcher.DispatchMatchingAlgorithmAttemptTimingEvent(
-                    SearchTrackingEventType.MatchingAlgorithmCoreMatchingStarted, DateTime.UtcNow);
-
                 var initialMatches = PerformMatchingPhaseOne(criteria, cutOffDate);
                 var matches = PerformMatchingPhaseTwo(criteria.AlleleLevelMatchCriteria, initialMatches);
                 var matchCount = 0;
@@ -70,9 +64,6 @@ namespace Atlas.MatchingAlgorithm.Services.Search.Matching
                     matchCount++;
                     yield return match;
                 }
-
-                await matchingAlgorithmSearchTrackingDispatcher.DispatchMatchingAlgorithmAttemptTimingEvent(
-                    SearchTrackingEventType.MatchingAlgorithmCoreMatchingEnded, DateTime.UtcNow);
 
                 searchLogger.SendTrace($"Matched {matchCount} donors");
             }

--- a/Atlas.MatchingAlgorithm/Services/Search/SearchRunner.cs
+++ b/Atlas.MatchingAlgorithm/Services/Search/SearchRunner.cs
@@ -17,7 +17,6 @@ using Atlas.MatchingAlgorithm.Services.ConfigurationProviders;
 using Atlas.MatchingAlgorithm.Settings.Azure;
 using Atlas.MatchingAlgorithm.Settings.ServiceBus;
 using Atlas.MatchingAlgorithm.Validators.SearchRequest;
-using Atlas.SearchTracking.Common.Enums;
 using FluentValidation;
 
 namespace Atlas.MatchingAlgorithm.Services.Search
@@ -91,7 +90,7 @@ namespace Atlas.MatchingAlgorithm.Services.Search
                 };
 
                 matchingAlgorithmSearchTrackingContextManager.Set(context);
-                await matchingAlgorithmSearchTrackingDispatcher.DispatchInitiationEvent(enqueuedTimeUtc.UtcDateTime, searchStartTime.UtcDateTime);
+                await matchingAlgorithmSearchTrackingDispatcher.ProcessInitiation(enqueuedTimeUtc.UtcDateTime, searchStartTime.UtcDateTime);
 
                 searchStopWatch.Start();
                 var results = (await searchService.Search(identifiedSearchRequest.SearchRequest, null)).ToList();

--- a/Atlas.RepeatSearch/Services/Search/RepeatSearchRunner.cs
+++ b/Atlas.RepeatSearch/Services/Search/RepeatSearchRunner.cs
@@ -104,7 +104,7 @@ namespace Atlas.RepeatSearch.Services.Search
                 };
 
                 matchingAlgorithmSearchTrackingContextManager.Set(context);
-                await matchingAlgorithmSearchTrackingDispatcher.DispatchInitiationEvent(enqueuedTimeUtc.UtcDateTime, searchStartTime.UtcDateTime);
+                await matchingAlgorithmSearchTrackingDispatcher.ProcessInitiation(enqueuedTimeUtc.UtcDateTime, searchStartTime.UtcDateTime);
 
                 // ReSharper disable once PossibleInvalidOperationException - validation has ensured this is not null.
                 var searchCutoffDate = identifiedRepeatSearchRequest.RepeatSearchRequest.SearchCutoffDate.Value;

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -14,8 +14,8 @@ variables:
   - group: TestTerraform
   - name: RUN_CI_PERF_TESTS_OFF
     value: 'This will get defined as an Environment Variable, which will enable various Perf-Test-only tests. See IgnoreExceptOnCiPerfTestAttribute.cs'
-  
-jobs: 
+
+jobs:
 - job: Terraform
   pool:
     vmImage: 'ubuntu-latest'
@@ -74,8 +74,8 @@ jobs:
 
           Write-Host("##vso[task.setvariable variable=$($prop.Name);isOutput=true;]$($prop.Value.value)")
           Write-Host(“Setting {0} to {1}” –f $prop.name, $prop.Value.value)
-          }      
-    
+          }
+
 - job: Matching_Algorithm_Integration_Tests
   dependsOn: Terraform
   variables:
@@ -114,7 +114,7 @@ jobs:
       command: test
       projects: '$(System.DefaultWorkingDirectory)/Atlas.MatchingAlgorithm.Test.Integration/Atlas.MatchingAlgorithm.Test.Integration.csproj'
       arguments: '--no-restore -v d'
-      
+
 - job: Matching_Algorithm_Validation_Tests
   dependsOn: Terraform
   variables:
@@ -142,7 +142,7 @@ jobs:
       filename: '$(System.DefaultWorkingDirectory)/Atlas.MatchingAlgorithm.Test.Validation/appsettings.json'
       keyname: DonorSql
       connectionstringvalue: '$(matching_algorithm_validation_db_connection_string)'
-      
+
   - task: bendayconsulting.build-task.setjsonconfigconnectionstring.setjsonconfigconnectionstring@1
     displayName: 'Update connection string ''SqlA'''
     inputs:
@@ -172,7 +172,7 @@ jobs:
       keyname1: AzureStorage
       keyname2: ConnectionString
       valueToSet: '$(azure_storage_account_connection_string)'
-      
+
   - task: bendayconsulting.build-task.setjsonvalue.setjsonvalue@1
     displayName: 'Set MAC Dictionary ConnectionString'
     inputs:
@@ -181,7 +181,7 @@ jobs:
       keyname1: MacDictionary
       keyname2: AzureStorageConnectionString
       valueToSet: '$(azure_storage_account_connection_string)'
-      
+
   - task: bendayconsulting.build-task.setjsonvalue.setjsonvalue@1
     displayName: 'Set HLA Metadata Dictionary ConnectionString'
     inputs:
@@ -198,7 +198,7 @@ jobs:
       numberOfLevels: 2
       keyname1: NotificationsServiceBus
       keyname2: ConnectionString
-#     ServiceBus is not used directly in tests, but DI will fail without a valid service bus connection string. 
+#     ServiceBus is not used directly in tests, but DI will fail without a valid service bus connection string.
       valueToSet: '$(SERVICE_BUS_CONNECTION_STRING)'
 
   - task: bendayconsulting.build-task.setjsonvalue.setjsonvalue@1
@@ -210,13 +210,22 @@ jobs:
       keyname2: ConnectionString
       valueToSet: '$(azure_app_configuration_connection_string)'
 
+  - task: bendayconsulting.build-task.setjsonvalue.setjsonvalue@1
+    displayName: 'Set Search Tracking Service Bus ConnectionString'
+    inputs:
+      filename: '$(System.DefaultWorkingDirectory)/Atlas.MatchingAlgorithm.Test.Validation/appsettings.json'
+      numberOfLevels: 2
+      keyname1: SearchTrackingServiceBus
+      keyname2: ConnectionString
+      valueToSet: '$(SERVICE_BUS_CONNECTION_STRING)'
+
   - task: DotNetCoreCLI@2
     displayName: 'Matching Validation Tests'
     inputs:
       command: test
       projects: '$(System.DefaultWorkingDirectory)/Atlas.MatchingAlgorithm.Test.Validation/Atlas.MatchingAlgorithm.Test.Validation.csproj'
       arguments: '--no-restore -v d'
-      
+
 - job: Donor_Import_Integration_Tests
   dependsOn: Terraform
   variables:
@@ -230,7 +239,7 @@ jobs:
         command: 'restore'
         feedsToUse: 'select'
     - task: bendayconsulting.build-task.setjsonconfigconnectionstring.setjsonconfigconnectionstring@1
-      displayName: 'Update Sql connection string' 
+      displayName: 'Update Sql connection string'
       inputs:
         filename: '$(System.DefaultWorkingDirectory)/Atlas.DonorImport.Test.Integration/appsettings.json'
         keyname: DonorStoreSql
@@ -255,7 +264,7 @@ jobs:
         command: 'restore'
         feedsToUse: 'select'
     - task: bendayconsulting.build-task.setjsonconfigconnectionstring.setjsonconfigconnectionstring@1
-      displayName: 'Update Sql connection string' 
+      displayName: 'Update Sql connection string'
       inputs:
         filename: '$(System.DefaultWorkingDirectory)/Atlas.MatchPrediction.Test.Integration/appsettings.json'
         keyname: MatchPredictionSql


### PR DESCRIPTION
Running a search that doesn't return any matches, results in the CoreScoringEnded Event being created whilst the CoreScoringStarted event isn't. Not sure how likely it is that a search will actually return 0 matches

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1362)
<!-- Reviewable:end -->
