### PR TITLE
fix: CBT-3084: Introduced Locus Value Replacement Mapping for Genotype Matcher in Match Prediction to handle C*04:09N -> C*04:09L rename

### DIFF
--- a/Atlas.MatchPrediction/Services/MatchProbability/GenotypeMatcher.cs
+++ b/Atlas.MatchPrediction/Services/MatchProbability/GenotypeMatcher.cs
@@ -54,6 +54,18 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
 
         private record GenotypeSet(bool IsUnrepresented, ICollection<GenotypeAtDesiredResolutions> Genotypes, decimal SumOfLikelihoods);
 
+        private readonly Dictionary<int, Dictionary<(Locus, string), string>> LocusValueReplacementMapping =
+            new()
+            {
+                {
+                    3590, new Dictionary<(Locus, string), string>
+                    {
+                        { (Locus.C, "*04:09N"), "*04:09L" },
+                        { (Locus.C, "04:09N"), "04:09L" },
+                    }
+                }
+            };
+
         public GenotypeMatcher(
             IGenotypeImputationService genotypeImputer,
             IGenotypeConverter genotypeConverter,
@@ -99,9 +111,46 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
 
         private async Task<GenotypeSet> GetGenotypeSetResultForMatchCounting(SubjectData subjectData, MatchPredictionParameters parameters)
         {
+            int? matchingAlgorithmHlaNomenclatureVersion = parameters.MatchingAlgorithmHlaNomenclatureVersion != null 
+                ? int.Parse(parameters.MatchingAlgorithmHlaNomenclatureVersion)
+                : null;
+
+            SubjectData preparedSubjectData;
+
+            if (matchingAlgorithmHlaNomenclatureVersion == null)
+            {
+                preparedSubjectData = subjectData;
+            }
+            else
+            {
+                var matchingReplacementMappingKeys = 
+                    LocusValueReplacementMapping.Keys
+                        .Where(k => k >= matchingAlgorithmHlaNomenclatureVersion)
+                        .ToList();
+
+                preparedSubjectData = new SubjectData(
+                    subjectData.HlaTyping.Map((locus, _, hla) =>
+                    {
+                        string replacement = null;
+                        foreach (var matchingReplacementMappingKey in matchingReplacementMappingKeys)
+                        {
+                            LocusValueReplacementMapping[matchingReplacementMappingKey].TryGetValue((locus, hla), out replacement);
+                        }
+
+                        if (replacement != null)
+                        {
+                            return replacement;
+                        }
+
+                        return hla;
+                    }),
+                    subjectData.SubjectFrequencySet
+                );
+            }
+
             var imputedGenotypes = await genotypeImputer.Impute(new ImputationInput
             {
-                SubjectData = subjectData,
+                SubjectData = preparedSubjectData,
                 MatchPredictionParameters = parameters
             });
 
@@ -112,13 +161,13 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
 
             var convertedGenotypes = await genotypeConverter.ConvertGenotypesForMatchCalculation(new GenotypeConverterInput
             {
-                CompressedPhenotype = subjectData.HlaTyping,
+                CompressedPhenotype = preparedSubjectData.HlaTyping,
                 AllowedLoci = parameters.AllowedLoci,
                 Genotypes = imputedGenotypes.Genotypes,
                 GenotypeLikelihoods = imputedGenotypes.GenotypeLikelihoods,
-                HfSetHlaNomenclatureVersion = subjectData.SubjectFrequencySet.FrequencySet.HlaNomenclatureVersion,
+                HfSetHlaNomenclatureVersion = preparedSubjectData.SubjectFrequencySet.FrequencySet.HlaNomenclatureVersion,
                 MatchingAlgorithmHlaNomenclatureVersion = parameters.MatchingAlgorithmHlaNomenclatureVersion,
-                SubjectLogDescription = subjectData.SubjectFrequencySet.SubjectLogDescription
+                SubjectLogDescription = preparedSubjectData.SubjectFrequencySet.SubjectLogDescription
             });
 
             return new GenotypeSet(false, convertedGenotypes, imputedGenotypes.SumOfLikelihoods);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1393)
<!-- Reviewable:end -->
