### PR TITLE
feat: ATL-13: implement worker project for match prediction

### DIFF
--- a/Atlas.HlaMetadataDictionary.Test/IntegrationTests/DependencyInjection/HlaMetadataDictionaryRegistrationTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/IntegrationTests/DependencyInjection/HlaMetadataDictionaryRegistrationTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.DependencyInjection;
 
-internal class HlaMetadataDictionaryRegistrationTests
+public class HlaMetadataDictionaryRegistrationTests
 {
     [Test]
     public void RegisterFileBasedHlaMetadataDictionaryForTesting_AllowsServiceProviderValidationOnBuild()

--- a/Atlas.HlaMetadataDictionary.Test/IntegrationTests/DependencyInjection/HlaMetadataDictionaryRegistrationTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/IntegrationTests/DependencyInjection/HlaMetadataDictionaryRegistrationTests.cs
@@ -1,0 +1,28 @@
+﻿using Atlas.Common.ApplicationInsights;
+using Atlas.MultipleAlleleCodeDictionary.Settings;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.DependencyInjection;
+
+internal class HlaMetadataDictionaryRegistrationTests
+{
+    [Test]
+    public void RegisterFileBasedHlaMetadataDictionaryForTesting_AllowsServiceProviderValidationOnBuild()
+    {
+        var services = new ServiceCollection();
+
+        services.RegisterFileBasedHlaMetadataDictionaryForTesting(
+            _ => new ApplicationInsightsSettings { LogLevel = "Info" },
+            _ => new MacDictionarySettings());
+
+        var buildProvider = () => services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        buildProvider.Should().NotThrow();
+    }
+}

--- a/Atlas.HlaMetadataDictionary/ExternalInterface/DependencyInjection/ServiceConfiguration.cs
+++ b/Atlas.HlaMetadataDictionary/ExternalInterface/DependencyInjection/ServiceConfiguration.cs
@@ -36,7 +36,6 @@ namespace Atlas.HlaMetadataDictionary.ExternalInterface.DependencyInjection
             services.RegisterLifeTimeScopedCacheTypes();
             services.RegisterCommonGeneticServices();
             services.AddScoped<IHlaMetadataDictionaryFactory, HlaMetadataDictionaryFactory>();
-            services.AddScoped<IHlaMetadataCacheControl, HlaMetadataCacheControl>();
             services.RegisterStorageTypes();
             services.RegisterTypesRelatedToDictionaryRecreation();
             services.RegisterServices();

--- a/Atlas.MatchPrediction.Worker/Atlas.MatchPrediction.Worker.csproj
+++ b/Atlas.MatchPrediction.Worker/Atlas.MatchPrediction.Worker.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>dotnet-Atlas.MatchPrediction.Worker-18c28d72-9dfc-4343-88da-bd6fb2703664</UserSecretsId>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Atlas.Common\Atlas.Common.csproj"/>
+        <ProjectReference Include="..\Atlas.Common.Public.Models\Atlas.Common.Public.Models.csproj"/>
+        <ProjectReference Include="..\Atlas.MatchPrediction\Atlas.MatchPrediction.csproj"/>
+    </ItemGroup>
+</Project>

--- a/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
+++ b/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
@@ -1,0 +1,58 @@
+using Atlas.Common.ServiceBus.BatchReceiving;
+using Atlas.MatchPrediction.Exceptions;
+using Atlas.MatchPrediction.ExternalInterface;
+using Atlas.MatchPrediction.ExternalInterface.Models;
+using Atlas.MatchPrediction.Worker.Settings;
+using Microsoft.Extensions.Options;
+
+namespace Atlas.MatchPrediction.Worker;
+
+public class MatchPredictionWorker(
+    IServiceScopeFactory serviceScopeFactory,
+    IServiceBusMessageReceiver<IdentifiedMatchPredictionRequest> messageReceiver,
+    IOptions<MatchPredictionWorkerSettings> settings,
+    ILogger<MatchPredictionWorker> logger) : BackgroundService
+{
+    private readonly int batchSize = settings.Value.BatchSize;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("MatchPredictionWorker starting.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var messages = (await messageReceiver.ReceiveMessageBatchAsync(batchSize)).ToList();
+
+            if (!messages.Any())
+            {
+                logger.LogInformation("No messages received, waiting for 5 seconds before retrying.");
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                continue;
+            }
+
+            using var batchLock = new MessageBatchLock<IdentifiedMatchPredictionRequest>(messageReceiver, messages);
+
+            try
+            {
+                await using var scope = serviceScopeFactory.CreateAsyncScope();
+                var runner = scope.ServiceProvider.GetRequiredService<IMatchPredictionRequestRunner>();
+                var requests = messages.Select(m => m.DeserializedBody).ToList();
+
+                await runner.RunMatchPredictionRequestBatch(requests);
+                await batchLock.CompleteBatchAsync();
+            }
+            catch (MatchPredictionRequestException ex)
+            {
+                logger.LogError(ex, "Unhandled error processing match prediction batch — abandoning batch.");
+                await batchLock.AbandonBatchAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error processing match prediction batch — abandoning batch.");
+                await batchLock.AbandonBatchAsync();
+            }
+        }
+
+        logger.LogInformation("MatchPredictionWorker stopping.");
+    }
+}

--- a/Atlas.MatchPrediction.Worker/Program.cs
+++ b/Atlas.MatchPrediction.Worker/Program.cs
@@ -1,0 +1,8 @@
+using Atlas.MatchPrediction.Worker;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+Startup.Configure(builder.Services);
+
+var host = builder.Build();
+host.Run();

--- a/Atlas.MatchPrediction.Worker/Properties/launchSettings.json
+++ b/Atlas.MatchPrediction.Worker/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Atlas.MatchPrediction.Worker": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Atlas.MatchPrediction.Worker/Settings/MatchPredictionWorkerSettings.cs
+++ b/Atlas.MatchPrediction.Worker/Settings/MatchPredictionWorkerSettings.cs
@@ -4,5 +4,5 @@ public class MatchPredictionWorkerSettings
 {
     public required string RequestsSubscription { get; set; }
 
-    public int BatchSize { get; set; } = 10;
+    public required int BatchSize { get; set; }
 }

--- a/Atlas.MatchPrediction.Worker/Settings/MatchPredictionWorkerSettings.cs
+++ b/Atlas.MatchPrediction.Worker/Settings/MatchPredictionWorkerSettings.cs
@@ -1,0 +1,8 @@
+namespace Atlas.MatchPrediction.Worker.Settings;
+
+public class MatchPredictionWorkerSettings
+{
+    public required string RequestsSubscription { get; set; }
+
+    public int BatchSize { get; set; } = 10;
+}

--- a/Atlas.MatchPrediction.Worker/Startup.cs
+++ b/Atlas.MatchPrediction.Worker/Startup.cs
@@ -1,0 +1,66 @@
+﻿using Atlas.Common.ApplicationInsights;
+using Atlas.Common.Notifications;
+using Atlas.Common.ServiceBus;
+using Atlas.Common.ServiceBus.BatchReceiving;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Settings;
+using Atlas.MatchPrediction.ExternalInterface.DependencyInjection;
+using Atlas.MatchPrediction.ExternalInterface.Models;
+using Atlas.MatchPrediction.ExternalInterface.Settings;
+using Atlas.MatchPrediction.Worker.Settings;
+using Atlas.MultipleAlleleCodeDictionary.Settings;
+using Microsoft.Extensions.Options;
+using static Atlas.Common.Utils.Extensions.DependencyInjectionUtils;
+
+namespace Atlas.MatchPrediction.Worker;
+
+public static class Startup
+{
+    public static void Configure(IServiceCollection services)
+    {
+        RegisterSettings(services);
+
+        services.RegisterMatchPredictionAlgorithm(
+            OptionsReaderFor<ApplicationInsightsSettings>(),
+            OptionsReaderFor<HlaMetadataDictionarySettings>(),
+            OptionsReaderFor<MacDictionarySettings>(),
+            OptionsReaderFor<NotificationsServiceBusSettings>(),
+            OptionsReaderFor<AzureStorageSettings>(),
+            ConnectionStringReader("MatchPredictionSql")
+        );
+
+        services.RegisterMatchPredictionRequester(
+            OptionsReaderFor<MessagingServiceBusSettings>(),
+            OptionsReaderFor<MatchPredictionRequestsSettings>()
+        );
+
+        services.AddSingleton<IServiceBusMessageReceiver<IdentifiedMatchPredictionRequest>>(sp =>
+            {
+                var requestSettings = sp.GetRequiredService<IOptions<MatchPredictionRequestsSettings>>().Value;
+                var workerSettings = sp.GetRequiredService<IOptions<MatchPredictionWorkerSettings>>().Value;
+                var factory = sp.GetRequiredKeyedService<IMessageReceiverFactory>(typeof(MessagingServiceBusSettings));
+                return new ServiceBusMessageReceiver<IdentifiedMatchPredictionRequest>(
+                    factory,
+                    requestSettings.RequestsTopic,
+                    workerSettings.RequestsSubscription,
+                    workerSettings.BatchSize
+                );
+            }
+        );
+
+        services.AddHostedService<MatchPredictionWorker>();
+    }
+
+    private static void RegisterSettings(IServiceCollection services)
+    {
+        services.RegisterAsOptions<ApplicationInsightsSettings>("ApplicationInsights");
+        services.RegisterAsOptions<AzureStorageSettings>("AzureStorage");
+        services.RegisterAsOptions<HlaMetadataDictionarySettings>("HlaMetadataDictionary");
+        services.RegisterAsOptions<MacDictionarySettings>("MacDictionary");
+
+        services.RegisterAsOptions<MatchPredictionRequestsSettings>("MatchPredictionRequests");
+        services.RegisterAsOptions<MessagingServiceBusSettings>("MessagingServiceBus");
+        services.RegisterAsOptions<NotificationsServiceBusSettings>("NotificationsServiceBus");
+
+        services.RegisterAsOptions<MatchPredictionWorkerSettings>("MatchPredictionWorker");
+    }
+}

--- a/Atlas.MatchPrediction.Worker/appsettings.json
+++ b/Atlas.MatchPrediction.Worker/appsettings.json
@@ -1,0 +1,47 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ApplicationInsights": {
+    "InstrumentationKey": "override-this",
+    "LogLevel": "Info"
+  },
+  "AzureStorage": {
+    "ConnectionString": "UseDevelopmentStorage=true",
+    "MatchPredictionResultsBlobContainer": "match-prediction-results"
+  },
+  "HlaMetadataDictionary": {
+    "AzureStorageConnectionString": "UseDevelopmentStorage=true",
+    "SearchRelatedMetadata": {
+      "CacheSlidingExpirationInSeconds": 300
+    }
+  },
+  "MacDictionary": {
+    "AzureStorageConnectionString": "UseDevelopmentStorage=true",
+    "TableName": "AtlasMultipleAlleleCodes"
+  },
+  "MessagingServiceBus": {
+    "ConnectionString": "override-this",
+    "SendRetryCount": 5,
+    "SendRetryCooldownSeconds": 20
+  },
+  "MatchPredictionRequests": {
+    "RequestsTopic": "match-prediction-requests",
+    "RequestsSubscription": "match-prediction",
+    "ResultsTopic": "match-prediction-results",
+    "BatchSize": 10
+  },
+  "NotificationsServiceBus": {
+    "ConnectionString": "override-this",
+    "AlertsTopic": "alerts",
+    "NotificationsTopic": "notifications",
+    "SendRetryCount": 5,
+    "SendRetryCooldownSeconds": 20
+  },
+  "ConnectionStrings": {
+    "MatchPredictionSql": "Data Source=(local);Initial Catalog=Atlas;Integrated Security=True;MultipleActiveResultSets=True;TrustServerCertificate=True;"
+  }
+}

--- a/Atlas.MatchPrediction.Worker/appsettings.json
+++ b/Atlas.MatchPrediction.Worker/appsettings.json
@@ -30,8 +30,10 @@
   },
   "MatchPredictionRequests": {
     "RequestsTopic": "match-prediction-requests",
+    "ResultsTopic": "match-prediction-results"
+  },
+  "MatchPredictionWorker": {
     "RequestsSubscription": "match-prediction",
-    "ResultsTopic": "match-prediction-results",
     "BatchSize": 10
   },
   "NotificationsServiceBus": {

--- a/Atlas.sln
+++ b/Atlas.sln
@@ -195,6 +195,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atlas.SearchTracking.Common
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atlas.SearchTracking.Test", "Atlas.SearchTracking.Test\Atlas.SearchTracking.Test.csproj", "{0F8CE404-8B26-4BB7-A9EA-EE2670C7ED4C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atlas.MatchPrediction.Worker", "Atlas.MatchPrediction.Worker\Atlas.MatchPrediction.Worker.csproj", "{78930DA4-037A-4C50-B819-090091394517}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -532,6 +534,12 @@ Global
 		{0F8CE404-8B26-4BB7-A9EA-EE2670C7ED4C}.Development|Any CPU.Build.0 = Debug|Any CPU
 		{0F8CE404-8B26-4BB7-A9EA-EE2670C7ED4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F8CE404-8B26-4BB7-A9EA-EE2670C7ED4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78930DA4-037A-4C50-B819-090091394517}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78930DA4-037A-4C50-B819-090091394517}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78930DA4-037A-4C50-B819-090091394517}.Development|Any CPU.ActiveCfg = Debug|Any CPU
+		{78930DA4-037A-4C50-B819-090091394517}.Development|Any CPU.Build.0 = Debug|Any CPU
+		{78930DA4-037A-4C50-B819-090091394517}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78930DA4-037A-4C50-B819-090091394517}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -592,6 +600,7 @@ Global
 		{BD29A7C5-30DA-49F4-9D5B-304BF75406C7} = {54F8399E-A9E6-4D36-A5B2-73C2023EF133}
 		{E7567A4A-9F17-4A27-96D7-D1B072BB6EFF} = {54F8399E-A9E6-4D36-A5B2-73C2023EF133}
 		{0F8CE404-8B26-4BB7-A9EA-EE2670C7ED4C} = {54F8399E-A9E6-4D36-A5B2-73C2023EF133}
+		{78930DA4-037A-4C50-B819-090091394517} = {8DF9D0B6-B94E-4680-8AB8-CB1509F23A74}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB0B0AD5-58AC-4CDF-826D-C653D03DC2AC}

--- a/README_MatchPredictionAlgorithm.md
+++ b/README_MatchPredictionAlgorithm.md
@@ -82,3 +82,28 @@ A high level overview of the match prediction algorithm's logic is as follows:
     - Note, the file does not contain a patient or donor ID; the consumer should map patient-donor IDs to request ID when initially submitting the request.
   - At this point, if any requests contain invalid properties, such invalid HLA, these will be indiviually caught and logged to Application Insights to allow users to correct them and re-submit.
     - Note: No alerts are sent out in such case; the user should manually monitor the logs, or use Application Insights monitoring.
+
+## Worker Project Configuration
+
+`Atlas.MatchPrediction.Worker` is a .NET Generic Host Worker Service (no Azure Functions dependency).
+Settings follow the same convention as other non-Functions projects: all values live in `appsettings.json`, with secrets marked `"override-this"`.
+
+Override secrets locally using **User Secrets**
+
+The following settings require real values to run locally:
+
+```json 
+{
+  "ApplicationInsights": {
+    "InstrumentationKey": "override-this"
+  },
+  "MessagingServiceBus": {
+    "ConnectionString": "override-this"
+  },
+  "NotificationsServiceBus": {
+    "ConnectionString": "override-this"
+  }
+}
+```
+All other settings have safe defaults for local development (Azurite for storage, local SQL Server for the database).
+


### PR DESCRIPTION
### Notes for this PR:
Nowadays, Microsoft recommends using Host.CreateApplicationBuilder instead of .CreateDefaultBuilder which is considered legacy; this approach was used to initialise the .Worker project.
Because of this, in DEVELOPMENT configuration when ServiceProvider is built it checks if scopes of the services are correct AND that each of the services added to the IServiceCollection can be instantiated. Due to this it was discovered that an instance of HlaMetadataCacheControl can't be instantiated because it requires a string argument injected from the DI (which is obviously not going to happen).
This did not surface before for two reasons:
- "Legacy" style host builders do not validate the DI;
- HlaMetadataCacheControl is never injected from the DI. As it is stated in the documentation (README_HlaMetadataDictionary.md) developers are not to inject anything directly and should use IHlaMetadataFactory instead, and this pattern was always followed.
So I removed the line which added this class into DI and added a test for sanity check of the DI.

Also note the usage of ILogger<> in the main worker file. It sends error traces to appinsights just fine but info traces only find their way into the console. Notify me to rewrite it to use our custom logger if necessary (or to fix it)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1440)
<!-- Reviewable:end -->
