### PR TITLE
Add Azure Container Apps instance for match prediction worker

### DIFF
--- a/terraform/core/container_apps_environment.tf
+++ b/terraform/core/container_apps_environment.tf
@@ -1,0 +1,11 @@
+resource "azurerm_container_app_environment" "atlas" {
+  name                       = "${local.environment}-ATLAS-CONTAINER-APPS-ENV"
+  location                   = local.location
+  resource_group_name        = azurerm_resource_group.atlas_resource_group.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.ai_workspace.id
+  tags                       = local.common_tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/core/container_registry.tf
+++ b/terraform/core/container_registry.tf
@@ -1,4 +1,5 @@
 data "azurerm_container_registry" "shared" {
+  provider            = azurerm.shared
   name                = var.ACR_NAME
   resource_group_name = var.ACR_RESOURCE_GROUP_NAME
 }

--- a/terraform/core/container_registry.tf
+++ b/terraform/core/container_registry.tf
@@ -1,0 +1,4 @@
+data "azurerm_container_registry" "shared" {
+  name                = var.ACR_NAME
+  resource_group_name = var.ACR_RESOURCE_GROUP_NAME
+}

--- a/terraform/core/identity.tf
+++ b/terraform/core/identity.tf
@@ -1,0 +1,12 @@
+resource "azurerm_user_assigned_identity" "acr_pull" {
+  name                = lower("${local.environment}-ATLAS-ID-ACR-PULL")
+  resource_group_name = azurerm_resource_group.atlas_resource_group.name
+  location            = local.location
+  tags                = local.common_tags
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  scope                = data.azurerm_container_registry.shared.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.acr_pull.principal_id
+}

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -194,10 +194,7 @@ module "match_prediction" {
 
   // Container Apps DI Variables
   container_app_environment = azurerm_container_app_environment.atlas
-  acr = {
-    id           = data.azurerm_container_registry.shared.id
-    login_server = data.azurerm_container_registry.shared.login_server
-  }
+  acr                       = data.azurerm_container_registry.shared
 
   // Release variables
   APPLICATION_INSIGHTS_LOG_LEVEL                           = var.APPLICATION_INSIGHTS_LOG_LEVEL

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -5,12 +5,13 @@ terraform {
 }
 
 locals {
-  repository_name     = "Atlas"
-  environment         = var.ENVIRONMENT
-  location            = var.LOCATION
-  min_tls_version     = "1.2"
-  resource_group_name = "${local.environment}-ATLAS-RESOURCE-GROUP"
-  subscription_id     = var.AZURE_SUBSCRIPTION_ID
+  repository_name          = "Atlas"
+  environment              = var.ENVIRONMENT
+  location                 = var.LOCATION
+  min_tls_version          = "1.2"
+  resource_group_name      = "${local.environment}-ATLAS-RESOURCE-GROUP"
+  subscription_id          = var.AZURE_SUBSCRIPTION_ID
+  shared_subscription_id   = var.SHARED_SUBSCRIPTION_ID
   common_tags = {
     controlled_by_terraform = true
     repository_name         = local.repository_name
@@ -27,6 +28,13 @@ provider "azurerm" {
   // initial registrations will need to be organised as a one-off.
   // Currently, the only resource provider needed is this AzureRM provider.
   skip_provider_registration = false
+  features {}
+}
+
+provider "azurerm" {
+  alias                      = "shared"
+  subscription_id            = local.shared_subscription_id
+  skip_provider_registration = true
   features {}
 }
 

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -203,6 +203,7 @@ module "match_prediction" {
   // Container Apps DI Variables
   container_app_environment = azurerm_container_app_environment.atlas
   acr                       = data.azurerm_container_registry.shared
+  acr_pull_identity         = azurerm_user_assigned_identity.acr_pull
 
   // Release variables
   APPLICATION_INSIGHTS_LOG_LEVEL                           = var.APPLICATION_INSIGHTS_LOG_LEVEL

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -192,6 +192,13 @@ module "match_prediction" {
     notifications = module.support.general.notifications_servicebus_topic
   }
 
+  // Container Apps DI Variables
+  container_app_environment = azurerm_container_app_environment.atlas
+  acr = {
+    id           = data.azurerm_container_registry.shared.id
+    login_server = data.azurerm_container_registry.shared.login_server
+  }
+
   // Release variables
   APPLICATION_INSIGHTS_LOG_LEVEL                           = var.APPLICATION_INSIGHTS_LOG_LEVEL
   DATABASE_PASSWORD                                        = var.MATCH_PREDICTION_DATABASE_PASSWORD
@@ -202,6 +209,11 @@ module "match_prediction" {
   SERVICE_BUS_SEND_RETRY_COUNT                             = var.SERVICE_BUS_SEND_RETRY_COUNT
   WEBSITE_RUN_FROM_PACKAGE                                 = var.WEBSITE_RUN_FROM_PACKAGE
   SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC = var.MATCH_PREDICTION_SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC
+  CONTAINER_IMAGE_TAG                                      = var.MATCH_PREDICTION_CONTAINER_IMAGE_TAG
+  CONTAINER_CPU                                            = var.MATCH_PREDICTION_CONTAINER_CPU
+  CONTAINER_MEMORY                                         = var.MATCH_PREDICTION_CONTAINER_MEMORY
+  CONTAINER_MIN_REPLICAS                                   = var.MATCH_PREDICTION_CONTAINER_MIN_REPLICAS
+  CONTAINER_MAX_REPLICAS                                   = var.MATCH_PREDICTION_CONTAINER_MAX_REPLICAS
 }
 
 module "multiple_allele_code_lookup" {

--- a/terraform/core/modules/match_prediction/container_app.tf
+++ b/terraform/core/modules/match_prediction/container_app.tf
@@ -10,7 +10,8 @@ resource "azurerm_container_app" "atlas_match_prediction" {
   tags                         = var.general.common_tags
 
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [var.acr_pull_identity.id]
   }
 
   template {
@@ -150,7 +151,7 @@ resource "azurerm_container_app" "atlas_match_prediction" {
 
   registry {
     server   = var.acr.login_server
-    identity = "System"
+    identity = var.acr_pull_identity.id
   }
 
   secret {
@@ -177,10 +178,4 @@ resource "azurerm_container_app" "atlas_match_prediction" {
     name  = "match-prediction-sql-connection-string"
     value = local.match_prediction_database_connection_string
   }
-}
-
-resource "azurerm_role_assignment" "match_prediction_ca_acr_pull" {
-  scope                = var.acr.id
-  role_definition_name = "AcrPull"
-  principal_id         = azurerm_container_app.atlas_match_prediction.identity[0].principal_id
 }

--- a/terraform/core/modules/match_prediction/container_app.tf
+++ b/terraform/core/modules/match_prediction/container_app.tf
@@ -1,0 +1,186 @@
+locals {
+  atlas_match_prediction_container_app_name = lower("${var.general.environment}-atlas-match-prediction-ca")
+}
+
+resource "azurerm_container_app" "atlas_match_prediction" {
+  name                         = local.atlas_match_prediction_container_app_name
+  container_app_environment_id = var.container_app_environment.id
+  resource_group_name          = var.app_service_plan.resource_group_name
+  revision_mode                = "Single"
+  tags                         = var.general.common_tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  template {
+    min_replicas = var.CONTAINER_MIN_REPLICAS
+    max_replicas = var.CONTAINER_MAX_REPLICAS
+
+    container {
+      name   = "match-prediction"
+      image  = "${var.acr.login_server}/atlas-match-prediction:${var.CONTAINER_IMAGE_TAG}"
+      cpu    = var.CONTAINER_CPU
+      memory = var.CONTAINER_MEMORY
+
+      // Application settings mirrored from function app
+      env {
+        name  = "ApplicationInsights__LogLevel"
+        value = var.APPLICATION_INSIGHTS_LOG_LEVEL
+      }
+      env {
+        name        = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+        secret_name = "appinsights-connection-string"
+      }
+
+      env {
+        name        = "AzureStorage__ConnectionString"
+        secret_name = "azure-storage-connection-string"
+      }
+      env {
+        name  = "AzureStorage__MatchPredictionResultsBlobContainer"
+        value = azurerm_storage_container.match_prediction_results_container.name
+      }
+
+      env {
+        name        = "HlaMetadataDictionary__AzureStorageConnectionString"
+        secret_name = "azure-storage-connection-string"
+      }
+      env {
+        name  = "HlaMetadataDictionary__SearchRelatedMetadata__CacheSlidingExpirationInSeconds"
+        value = var.SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC != null ? tostring(var.SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC) : ""
+      }
+
+      env {
+        name        = "MacDictionary__AzureStorageConnectionString"
+        secret_name = "azure-storage-connection-string"
+      }
+      env {
+        name  = "MacDictionary__TableName"
+        value = var.mac_import_table.name
+      }
+
+      env {
+        name        = "MessagingServiceBus__ConnectionString"
+        secret_name = "servicebus-manage-connection-string"
+      }
+      env {
+        name  = "MessagingServiceBus__ImportFileSubscription"
+        value = azurerm_servicebus_subscription.haplotype-frequency-file-processor.name
+      }
+      env {
+        name  = "MessagingServiceBus__ImportFileTopic"
+        value = azurerm_servicebus_topic.haplotype-frequency-file-uploads.name
+      }
+      env {
+        name  = "MessagingServiceBus__SendRetryCount"
+        value = tostring(var.SERVICE_BUS_SEND_RETRY_COUNT)
+      }
+      env {
+        name  = "MessagingServiceBus__SendRetryCooldownSeconds"
+        value = tostring(var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS)
+      }
+
+      env {
+        name  = "MatchPredictionRequests__RequestsSubscription"
+        value = azurerm_servicebus_subscription.match-prediction-request-runner.name
+      }
+      env {
+        name  = "MatchPredictionRequests__RequestsTopic"
+        value = azurerm_servicebus_topic.match-prediction-requests.name
+      }
+      env {
+        name  = "MatchPredictionRequests__ResultsTopic"
+        value = azurerm_servicebus_topic.match-prediction-results.name
+      }
+
+      env {
+        name        = "NotificationsServiceBus__ConnectionString"
+        secret_name = "servicebus-write-only-connection-string"
+      }
+      env {
+        name  = "NotificationsServiceBus__AlertsTopic"
+        value = var.servicebus_topics.alerts.name
+      }
+      env {
+        name  = "NotificationsServiceBus__NotificationsTopic"
+        value = var.servicebus_topics.notifications.name
+      }
+      env {
+        name  = "NotificationsServiceBus__SendRetryCount"
+        value = tostring(var.SERVICE_BUS_SEND_RETRY_COUNT)
+      }
+      env {
+        name  = "NotificationsServiceBus__SendRetryCooldownSeconds"
+        value = tostring(var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS)
+      }
+
+      env {
+        name        = "ConnectionStrings__MatchPredictionSql"
+        secret_name = "match-prediction-sql-connection-string"
+      }
+
+      liveness_probe {
+        path             = "/api/HealthCheck"
+        port             = 8080
+        transport        = "HTTP"
+        initial_delay    = 10
+        interval_seconds = 30
+      }
+
+      readiness_probe {
+        path             = "/api/HealthCheck"
+        port             = 8080
+        transport        = "HTTP"
+        interval_seconds = 10
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+    transport        = "http"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  registry {
+    server   = var.acr.login_server
+    identity = "System"
+  }
+
+  secret {
+    name  = "appinsights-connection-string"
+    value = var.application_insights.connection_string
+  }
+
+  secret {
+    name  = "azure-storage-connection-string"
+    value = var.azure_storage.primary_connection_string
+  }
+
+  secret {
+    name  = "servicebus-manage-connection-string"
+    value = var.servicebus_namespace_authorization_rules.manage.primary_connection_string
+  }
+
+  secret {
+    name  = "servicebus-write-only-connection-string"
+    value = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
+  }
+
+  secret {
+    name  = "match-prediction-sql-connection-string"
+    value = local.match_prediction_database_connection_string
+  }
+}
+
+resource "azurerm_role_assignment" "match_prediction_ca_acr_pull" {
+  scope                = var.acr.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_container_app.atlas_match_prediction.identity[0].principal_id
+}

--- a/terraform/core/modules/match_prediction/container_app.tf
+++ b/terraform/core/modules/match_prediction/container_app.tf
@@ -122,16 +122,16 @@ resource "azurerm_container_app" "atlas_match_prediction" {
       }
 
       liveness_probe {
-        path             = "/api/HealthCheck"
-        port             = 8080
+        path             = "/health/live"
+        port             = 80
         transport        = "HTTP"
         initial_delay    = 10
         interval_seconds = 30
       }
 
       readiness_probe {
-        path             = "/api/HealthCheck"
-        port             = 8080
+        path             = "/health/ready"
+        port             = 80
         transport        = "HTTP"
         interval_seconds = 10
       }

--- a/terraform/core/modules/match_prediction/outputs.tf
+++ b/terraform/core/modules/match_prediction/outputs.tf
@@ -19,3 +19,11 @@ output "sql_database" {
     connection_string = local.match_prediction_database_connection_string
   }
 }
+
+output "container_app" {
+  value = {
+    fqdn              = azurerm_container_app.atlas_match_prediction.ingress[0].fqdn
+    name              = azurerm_container_app.atlas_match_prediction.name
+    latest_revision   = azurerm_container_app.atlas_match_prediction.latest_revision_name
+  }
+}

--- a/terraform/core/modules/match_prediction/variables_di.tf
+++ b/terraform/core/modules/match_prediction/variables_di.tf
@@ -10,6 +10,7 @@ variable "app_service_plan" {
 variable "application_insights" {
   type = object({
     instrumentation_key = string
+    connection_string   = string
   })
 }
 
@@ -68,5 +69,18 @@ variable "sql_server" {
     id                          = string
     name                        = string
     fully_qualified_domain_name = string
+  })
+}
+
+variable "container_app_environment" {
+  type = object({
+    id = string
+  })
+}
+
+variable "acr" {
+  type = object({
+    id           = string
+    login_server = string
   })
 }

--- a/terraform/core/modules/match_prediction/variables_di.tf
+++ b/terraform/core/modules/match_prediction/variables_di.tf
@@ -84,3 +84,10 @@ variable "acr" {
     login_server = string
   })
 }
+
+variable "acr_pull_identity" {
+  type = object({
+    id           = string
+    principal_id = string
+  })
+}

--- a/terraform/core/modules/match_prediction/variables_release.tf
+++ b/terraform/core/modules/match_prediction/variables_release.tf
@@ -37,3 +37,30 @@ variable "SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC" {
   type     = number
   nullable = true
 }
+
+// Container App release variables
+
+variable "CONTAINER_IMAGE_TAG" {
+  type    = string
+  default = "latest"
+}
+
+variable "CONTAINER_CPU" {
+  type    = number
+  default = 1.0
+}
+
+variable "CONTAINER_MEMORY" {
+  type    = string
+  default = "2Gi"
+}
+
+variable "CONTAINER_MIN_REPLICAS" {
+  type    = number
+  default = 0
+}
+
+variable "CONTAINER_MAX_REPLICAS" {
+  type    = number
+  default = 1
+}

--- a/terraform/core/outputs.tf
+++ b/terraform/core/outputs.tf
@@ -58,3 +58,10 @@ output "storage_account" {
 output "support" {
   value = module.support
 }
+
+output "container_app_environment" {
+  value = {
+    id   = azurerm_container_app_environment.atlas.id
+    name = azurerm_container_app_environment.atlas.name
+  }
+}

--- a/terraform/core/outputs_ci.tf
+++ b/terraform/core/outputs_ci.tf
@@ -96,3 +96,11 @@ output "sql-server-admin-login" {
 output "sql-server-admin-login-password" {
   value = var.DATABASE_SERVER_ADMIN_LOGIN_PASSWORD
 }
+
+output "match-prediction-container-app-name" {
+  value = module.match_prediction.container_app.name
+}
+
+output "container-app-environment-name" {
+  value = azurerm_container_app_environment.atlas.name
+}

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -537,6 +537,12 @@ variable "ACR_RESOURCE_GROUP_NAME" {
   description = "Resource group of the shared Azure Container Registry."
 }
 
+variable "SHARED_SUBSCRIPTION_ID" {
+  type        = string
+  default     = "f37d6d06-4bc8-4146-add7-fe2911b47e11"
+  description = "Subscription ID where shared organization-level resources reside (e.g., Container Registry)."
+}
+
 variable "MATCH_PREDICTION_CONTAINER_IMAGE_TAG" {
   type        = string
   default     = "latest"

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -527,11 +527,13 @@ variable "SUPPORT_DEADLETTER_ALERTS_ACTION_GROUP_ID" {
 
 variable "ACR_NAME" {
   type        = string
+  default     = "ancontainerregistry"
   description = "Name of the shared Azure Container Registry."
 }
 
 variable "ACR_RESOURCE_GROUP_NAME" {
   type        = string
+  default     = "AN-RESOURCE-GROUP"
   description = "Resource group of the shared Azure Container Registry."
 }
 

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -522,3 +522,45 @@ variable "SUPPORT_DEADLETTER_ALERTS_ACTION_GROUP_ID" {
   default     = null
   description = "The ID of the action group to be used for deadletter alerts."
 }
+
+// Container Apps / ACR
+
+variable "ACR_NAME" {
+  type        = string
+  description = "Name of the shared Azure Container Registry."
+}
+
+variable "ACR_RESOURCE_GROUP_NAME" {
+  type        = string
+  description = "Resource group of the shared Azure Container Registry."
+}
+
+variable "MATCH_PREDICTION_CONTAINER_IMAGE_TAG" {
+  type        = string
+  default     = "latest"
+  description = "Docker image tag for the match prediction container app."
+}
+
+variable "MATCH_PREDICTION_CONTAINER_CPU" {
+  type        = number
+  default     = 1.0
+  description = "CPU cores allocated to the match prediction container app."
+}
+
+variable "MATCH_PREDICTION_CONTAINER_MEMORY" {
+  type        = string
+  default     = "2Gi"
+  description = "Memory allocated to the match prediction container app."
+}
+
+variable "MATCH_PREDICTION_CONTAINER_MIN_REPLICAS" {
+  type        = number
+  default     = 0
+  description = "Minimum replica count for the match prediction container app."
+}
+
+variable "MATCH_PREDICTION_CONTAINER_MAX_REPLICAS" {
+  type        = number
+  default     = 1
+  description = "Maximum replica count for the match prediction container app."
+}


### PR DESCRIPTION

Introduce modules for Azure Container Registry (ACR), Azure Container Environment (ACE) and match prediction worker Azure Container App (ACA), along with necessary configurations and default variable values. Implement user-assigned identity for ACR pull and update container app settings accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1445)
<!-- Reviewable:end -->
