### PR TITLE
Feature: ATL-67: add Terraform ignore blocks

### DIFF
--- a/terraform/core/function.tf
+++ b/terraform/core/function.tf
@@ -107,6 +107,7 @@ resource "azurerm_windows_function_app" "atlas_function" {
     ignore_changes = [
       site_config[0].health_check_eviction_time_in_min,
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 
@@ -205,6 +206,7 @@ resource "azurerm_windows_function_app" "atlas_public_api_function" {
     ignore_changes = [
       site_config[0].health_check_eviction_time_in_min,
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
 
     replace_triggered_by = [

--- a/terraform/core/function.tf
+++ b/terraform/core/function.tf
@@ -103,6 +103,13 @@ resource "azurerm_windows_function_app" "atlas_function" {
     "WEBSITE_RUN_FROM_PACKAGE"                                = var.WEBSITE_RUN_FROM_PACKAGE
   }
 
+  lifecycle {
+    ignore_changes = [
+      site_config[0].health_check_eviction_time_in_min,
+      site_config[0].cors,
+    ]
+  }
+
   connection_string {
     name  = "Matching:Sql:Persistent"
     type  = "SQLAzure"
@@ -195,6 +202,11 @@ resource "azurerm_windows_function_app" "atlas_public_api_function" {
   }
 
   lifecycle {
+    ignore_changes = [
+      site_config[0].health_check_eviction_time_in_min,
+      site_config[0].cors,
+    ]
+
     replace_triggered_by = [
       # Recreate the entire functions app if the service plan changes.
       # This is necessary in case of updating var from `true` to `false`, as terraform attempts to destroy the public API service plan /before/ modifying the function app's service_plan_id.

--- a/terraform/core/modules/donor_import/function.tf
+++ b/terraform/core/modules/donor_import/function.tf
@@ -96,6 +96,7 @@ resource "azurerm_windows_function_app" "atlas_donor_import_function" {
     ignore_changes = [
       site_config[0].health_check_eviction_time_in_min,
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 }

--- a/terraform/core/modules/donor_import/function.tf
+++ b/terraform/core/modules/donor_import/function.tf
@@ -91,4 +91,11 @@ resource "azurerm_windows_function_app" "atlas_donor_import_function" {
     type  = "SQLAzure"
     value = local.donor_import_connection_string
   }
+
+  lifecycle {
+    ignore_changes = [
+      site_config[0].health_check_eviction_time_in_min,
+      site_config[0].cors,
+    ]
+  }
 }

--- a/terraform/core/modules/match_prediction/function.tf
+++ b/terraform/core/modules/match_prediction/function.tf
@@ -77,4 +77,11 @@ resource "azurerm_windows_function_app" "atlas_match_prediction_function" {
     type  = "SQLAzure"
     value = local.match_prediction_database_connection_string
   }
+
+  lifecycle {
+    ignore_changes = [
+      site_config[0].health_check_eviction_time_in_min,
+      site_config[0].cors,
+    ]
+  }
 }

--- a/terraform/core/modules/match_prediction/function.tf
+++ b/terraform/core/modules/match_prediction/function.tf
@@ -82,6 +82,7 @@ resource "azurerm_windows_function_app" "atlas_match_prediction_function" {
     ignore_changes = [
       site_config[0].health_check_eviction_time_in_min,
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 }

--- a/terraform/core/modules/matching_algorithm/donor_management_function.tf
+++ b/terraform/core/modules/matching_algorithm/donor_management_function.tf
@@ -93,6 +93,7 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_donor_manageme
   lifecycle {
     ignore_changes = [
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 }

--- a/terraform/core/modules/matching_algorithm/donor_management_function.tf
+++ b/terraform/core/modules/matching_algorithm/donor_management_function.tf
@@ -89,4 +89,10 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_donor_manageme
     type  = "SQLAzure"
     value = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.donor_import_sql_database.name};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   }
+
+  lifecycle {
+    ignore_changes = [
+      site_config[0].cors,
+    ]
+  }
 }

--- a/terraform/core/modules/matching_algorithm/matching_algorithm_function.tf
+++ b/terraform/core/modules/matching_algorithm/matching_algorithm_function.tf
@@ -149,6 +149,12 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_function" {
     type  = "SQLAzure"
     value = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.donor_import_sql_database.name};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   }
+
+  lifecycle {
+    ignore_changes = [
+      site_config[0].cors,
+    ]
+  }
 }
 
 data "azurerm_function_app_host_keys" "atlas_matching_algorithm_function_keys" {

--- a/terraform/core/modules/matching_algorithm/matching_algorithm_function.tf
+++ b/terraform/core/modules/matching_algorithm/matching_algorithm_function.tf
@@ -153,6 +153,7 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_function" {
   lifecycle {
     ignore_changes = [
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 }

--- a/terraform/core/modules/repeat_search/function.tf
+++ b/terraform/core/modules/repeat_search/function.tf
@@ -120,6 +120,7 @@ resource "azurerm_windows_function_app" "atlas_repeat_search_function" {
     ignore_changes = [
       site_config[0].health_check_eviction_time_in_min,
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 }

--- a/terraform/core/modules/repeat_search/function.tf
+++ b/terraform/core/modules/repeat_search/function.tf
@@ -115,4 +115,11 @@ resource "azurerm_windows_function_app" "atlas_repeat_search_function" {
     type  = "SQLAzure"
     value = var.donor_database_connection_string
   }
+
+  lifecycle {
+    ignore_changes = [
+      site_config[0].health_check_eviction_time_in_min,
+      site_config[0].cors,
+    ]
+  }
 }

--- a/terraform/core/modules/search_tracking/function.tf
+++ b/terraform/core/modules/search_tracking/function.tf
@@ -55,4 +55,11 @@ resource "azurerm_windows_function_app" "atlas_search_tracking_function" {
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.0"
   }
+
+  lifecycle {
+    ignore_changes = [
+      site_config[0].health_check_eviction_time_in_min,
+      site_config[0].cors,
+    ]
+  }
 }

--- a/terraform/core/modules/search_tracking/function.tf
+++ b/terraform/core/modules/search_tracking/function.tf
@@ -60,6 +60,7 @@ resource "azurerm_windows_function_app" "atlas_search_tracking_function" {
     ignore_changes = [
       site_config[0].health_check_eviction_time_in_min,
       site_config[0].cors,
+      tags["hidden-link: /app-insights-resource-id"],
     ]
   }
 }


### PR DESCRIPTION
Adds `lifecycle` ignore blocks to Terraform modules to prevent unintended drift on fields managed outside of IaC.

Improves plan stability and reduces noise in `terraform plan` output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1451)
<!-- Reviewable:end -->
