### PR TITLE
feature: atl-83: add external SQL configuration for retargeting function app connection strings

### DIFF
--- a/terraform/core/function.tf
+++ b/terraform/core/function.tf
@@ -65,10 +65,10 @@ resource "azurerm_windows_function_app" "atlas_function" {
     "AtlasFunction:MessagingServiceBus:SearchResultsTopic"                      = azurerm_servicebus_topic.search-results-ready.name
     "AtlasFunction:MessagingServiceBus:SearchResultsDebugSubscription"          = azurerm_servicebus_subscription.debug-search-results-ready.name
     "AtlasFunction:MessagingServiceBus:RepeatSearchResultsDebugSubscription"    = module.repeat_search.service_bus.repeat_search_results_debug_subscription.name
-    "AtlasFunction:MessagingServiceBus:SendRetryCount"                                 = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "AtlasFunction:MessagingServiceBus:SendRetryCooldownSeconds"                        = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
-    "AtlasFunction:MessagingServiceBus:ParallelMatchPredictionRequestsTopic"            = module.match_prediction.service_bus.parallel_match_prediction_requests_topic.name
-    "AtlasFunction:Orchestration:MatchPredictionBatchSize"                             = var.ORCHESTRATION_MATCH_PREDICTION_BATCH_SIZE
+    "AtlasFunction:MessagingServiceBus:SendRetryCount"                          = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "AtlasFunction:MessagingServiceBus:SendRetryCooldownSeconds"                = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "AtlasFunction:MessagingServiceBus:ParallelMatchPredictionRequestsTopic"    = module.match_prediction.service_bus.parallel_match_prediction_requests_topic.name
+    "AtlasFunction:Orchestration:MatchPredictionBatchSize"                      = var.ORCHESTRATION_MATCH_PREDICTION_BATCH_SIZE
 
     "HlaMetadataDictionary:AzureStorageConnectionString"                          = azurerm_storage_account.azure_storage.primary_connection_string
     "HlaMetadataDictionary:HlaNomenclatureSourceUrl"                              = var.WMDA_FILE_URL
@@ -175,8 +175,8 @@ resource "azurerm_windows_function_app" "atlas_public_api_function" {
   app_settings = {
     "ApplicationInsights:LogLevel" = var.APPLICATION_INSIGHTS_LOG_LEVEL
 
-    "MatchingAlgorithmFunction:BaseUrl"                = module.matching_algorithm.function_app.base_url
-    "MatchingAlgorithmFunction:ApiKey"                 = module.matching_algorithm.function_app.api_key
+    "MatchingAlgorithmFunction:BaseUrl" = module.matching_algorithm.function_app.base_url
+    "MatchingAlgorithmFunction:ApiKey"  = module.matching_algorithm.function_app.api_key
 
     "Matching:MessagingServiceBus:ConnectionString"         = azurerm_servicebus_namespace_authorization_rule.read-write.primary_connection_string
     "Matching:MessagingServiceBus:SearchRequestsTopic"      = module.matching_algorithm.service_bus.matching_requests_topic.name
@@ -184,21 +184,21 @@ resource "azurerm_windows_function_app" "atlas_public_api_function" {
     "Matching:MessagingServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
     "Matching:MessagingServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "RepeatSearch:MessagingServiceBus:ConnectionString"           = azurerm_servicebus_namespace_authorization_rule.read-write.primary_connection_string
-    "RepeatSearch:MessagingServiceBus:RepeatSearchRequestsTopic"  = module.repeat_search.service_bus.repeat_search_requests_topic.name
-    "RepeatSearch:MessagingServiceBus:SendRetryCount"             = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "RepeatSearch:MessagingServiceBus:SendRetryCooldownSeconds"   = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "RepeatSearch:MessagingServiceBus:ConnectionString"          = azurerm_servicebus_namespace_authorization_rule.read-write.primary_connection_string
+    "RepeatSearch:MessagingServiceBus:RepeatSearchRequestsTopic" = module.repeat_search.service_bus.repeat_search_requests_topic.name
+    "RepeatSearch:MessagingServiceBus:SendRetryCount"            = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "RepeatSearch:MessagingServiceBus:SendRetryCooldownSeconds"  = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
     "SearchTracking:SearchTrackingServiceBus:ConnectionString"         = azurerm_servicebus_namespace_authorization_rule.read-write.primary_connection_string
     "SearchTracking:SearchTrackingServiceBus:SearchTrackingTopic"      = module.search_tracking.service_bus.search_tracking_topic.name
     "SearchTracking:SearchTrackingServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
     "SearchTracking:SearchTrackingServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "NotificationsServiceBus:AlertsTopic"                = module.support.general.alerts_servicebus_topic.name
-    "NotificationsServiceBus:ConnectionString"           = azurerm_servicebus_namespace_authorization_rule.write-only.primary_connection_string
-    "NotificationsServiceBus:NotificationsTopic"         = module.support.general.notifications_servicebus_topic.name
-    "NotificationsServiceBus:SendRetryCount"             = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "NotificationsServiceBus:SendRetryCooldownSeconds"   = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "NotificationsServiceBus:AlertsTopic"              = module.support.general.alerts_servicebus_topic.name
+    "NotificationsServiceBus:ConnectionString"         = azurerm_servicebus_namespace_authorization_rule.write-only.primary_connection_string
+    "NotificationsServiceBus:NotificationsTopic"       = module.support.general.notifications_servicebus_topic.name
+    "NotificationsServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "NotificationsServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
     "WEBSITE_RUN_FROM_PACKAGE" = var.WEBSITE_RUN_FROM_PACKAGE
   }

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -91,9 +91,9 @@ module "donor_import" {
   ALLOW_FULL_MODE_IMPORT                        = var.DONOR_IMPORT_ALLOW_FULL_MODE_IMPORT
 
   // External SQL variables
-  use_external_sql         = var.use_external_sql
-  external_sql_server_name = var.external_sql_server_name
-  external_sql_db_shared   = var.external_sql_db_shared
+  USE_EXTERNAL_SQL         = var.USE_EXTERNAL_SQL
+  EXTERNAL_SQL_SERVER_NAME = var.EXTERNAL_SQL_SERVER_NAME
+  EXTERNAL_SQL_DB_SHARED   = var.EXTERNAL_SQL_DB_SHARED
 }
 
 module "matching_algorithm" {
@@ -173,11 +173,11 @@ module "matching_algorithm" {
   SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC = var.MATCHING_ALGORITHM_SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC
 
   // External SQL variables
-  use_external_sql           = var.use_external_sql
-  external_sql_server_name   = var.external_sql_server_name
-  external_sql_db_shared     = var.external_sql_db_shared
-  external_sql_db_matching_a = var.external_sql_db_matching_a
-  external_sql_db_matching_b = var.external_sql_db_matching_b
+  USE_EXTERNAL_SQL           = var.USE_EXTERNAL_SQL
+  EXTERNAL_SQL_SERVER_NAME   = var.EXTERNAL_SQL_SERVER_NAME
+  EXTERNAL_SQL_DB_SHARED     = var.EXTERNAL_SQL_DB_SHARED
+  EXTERNAL_SQL_DB_MATCHING_A = var.EXTERNAL_SQL_DB_MATCHING_A
+  EXTERNAL_SQL_DB_MATCHING_B = var.EXTERNAL_SQL_DB_MATCHING_B
 }
 
 module "match_prediction" {
@@ -237,9 +237,9 @@ module "match_prediction" {
   CONTAINER_MAX_REPLICAS                                   = var.MATCH_PREDICTION_CONTAINER_MAX_REPLICAS
 
   // External SQL variables
-  use_external_sql         = var.use_external_sql
-  external_sql_server_name = var.external_sql_server_name
-  external_sql_db_shared   = var.external_sql_db_shared
+  USE_EXTERNAL_SQL         = var.USE_EXTERNAL_SQL
+  EXTERNAL_SQL_SERVER_NAME = var.EXTERNAL_SQL_SERVER_NAME
+  EXTERNAL_SQL_DB_SHARED   = var.EXTERNAL_SQL_DB_SHARED
 }
 
 module "multiple_allele_code_lookup" {
@@ -302,9 +302,9 @@ module "repeat_search" {
   STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT           = var.STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT
 
   // External SQL variables
-  use_external_sql         = var.use_external_sql
-  external_sql_server_name = var.external_sql_server_name
-  external_sql_db_shared   = var.external_sql_db_shared
+  USE_EXTERNAL_SQL         = var.USE_EXTERNAL_SQL
+  EXTERNAL_SQL_SERVER_NAME = var.EXTERNAL_SQL_SERVER_NAME
+  EXTERNAL_SQL_DB_SHARED   = var.EXTERNAL_SQL_DB_SHARED
 }
 
 module "search_tracking" {
@@ -338,9 +338,9 @@ module "search_tracking" {
   IP_RESTRICTION_SETTINGS        = var.IP_RESTRICTION_SETTINGS
 
   // External SQL variables
-  use_external_sql         = var.use_external_sql
-  external_sql_server_name = var.external_sql_server_name
-  external_sql_db_shared   = var.external_sql_db_shared
+  USE_EXTERNAL_SQL         = var.USE_EXTERNAL_SQL
+  EXTERNAL_SQL_SERVER_NAME = var.EXTERNAL_SQL_SERVER_NAME
+  EXTERNAL_SQL_DB_SHARED   = var.EXTERNAL_SQL_DB_SHARED
 }
 
 module "support" {

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -89,6 +89,11 @@ module "donor_import" {
   FAILURE_LOGS_CRONTAB                          = var.DONOR_IMPORT_FAILURE_LOGS_CRONTAB
   FAILURE_LOGS_EXPIRY_IN_DAYS                   = var.DONOR_IMPORT_FAILURE_LOGS_EXPIRY_IN_DAYS
   ALLOW_FULL_MODE_IMPORT                        = var.DONOR_IMPORT_ALLOW_FULL_MODE_IMPORT
+
+  // External SQL variables
+  use_external_sql         = var.use_external_sql
+  external_sql_server_name = var.external_sql_server_name
+  external_sql_db_shared   = var.external_sql_db_shared
 }
 
 module "matching_algorithm" {
@@ -166,6 +171,13 @@ module "matching_algorithm" {
   WEBSITE_RUN_FROM_PACKAGE                                 = var.WEBSITE_RUN_FROM_PACKAGE
   WMDA_FILE_URL                                            = var.WMDA_FILE_URL
   SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC = var.MATCHING_ALGORITHM_SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC
+
+  // External SQL variables
+  use_external_sql           = var.use_external_sql
+  external_sql_server_name   = var.external_sql_server_name
+  external_sql_db_shared     = var.external_sql_db_shared
+  external_sql_db_matching_a = var.external_sql_db_matching_a
+  external_sql_db_matching_b = var.external_sql_db_matching_b
 }
 
 module "match_prediction" {
@@ -223,6 +235,11 @@ module "match_prediction" {
   CONTAINER_MEMORY                                         = var.MATCH_PREDICTION_CONTAINER_MEMORY
   CONTAINER_MIN_REPLICAS                                   = var.MATCH_PREDICTION_CONTAINER_MIN_REPLICAS
   CONTAINER_MAX_REPLICAS                                   = var.MATCH_PREDICTION_CONTAINER_MAX_REPLICAS
+
+  // External SQL variables
+  use_external_sql         = var.use_external_sql
+  external_sql_server_name = var.external_sql_server_name
+  external_sql_db_shared   = var.external_sql_db_shared
 }
 
 module "multiple_allele_code_lookup" {
@@ -283,6 +300,11 @@ module "repeat_search" {
   SERVICE_BUS_SEND_RETRY_COUNT                             = var.SERVICE_BUS_SEND_RETRY_COUNT
   STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_BATCHSIZE         = var.STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_BATCHSIZE
   STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT           = var.STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT
+
+  // External SQL variables
+  use_external_sql         = var.use_external_sql
+  external_sql_server_name = var.external_sql_server_name
+  external_sql_db_shared   = var.external_sql_db_shared
 }
 
 module "search_tracking" {
@@ -314,6 +336,11 @@ module "search_tracking" {
   DATABASE_PASSWORD              = var.SEARCH_TRACKING_DATABASE_PASSWORD
   DATABASE_USERNAME              = var.SEARCH_TRACKING_DATABASE_USERNAME
   IP_RESTRICTION_SETTINGS        = var.IP_RESTRICTION_SETTINGS
+
+  // External SQL variables
+  use_external_sql         = var.use_external_sql
+  external_sql_server_name = var.external_sql_server_name
+  external_sql_db_shared   = var.external_sql_db_shared
 }
 
 module "support" {

--- a/terraform/core/modules/donor_import/function.tf
+++ b/terraform/core/modules/donor_import/function.tf
@@ -44,11 +44,11 @@ resource "azurerm_windows_function_app" "atlas_donor_import_function" {
 
     "NotificationConfiguration:NotifyOnAttemptedDeletionOfUntrackedDonor" = var.NOTIFICATIONS_ON_DELETION_OF_INVALID_DONOR
 
-    "NotificationsServiceBus:AlertsTopic"               = var.servicebus_topics.alerts.name
-    "NotificationsServiceBus:ConnectionString"          = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
-    "NotificationsServiceBus:NotificationsTopic"        = var.servicebus_topics.notifications.name
-    "NotificationsServiceBus:SendRetryCount"            = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "NotificationsServiceBus:SendRetryCooldownSeconds"  = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "NotificationsServiceBus:AlertsTopic"              = var.servicebus_topics.alerts.name
+    "NotificationsServiceBus:ConnectionString"         = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
+    "NotificationsServiceBus:NotificationsTopic"       = var.servicebus_topics.notifications.name
+    "NotificationsServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "NotificationsServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
     "PublishDonorUpdates:DeletionCronSchedule"              = var.DELETE_PUBLISHED_DONOR_UPDATES_CRONTAB
     "PublishDonorUpdates:PublishCronSchedule"               = var.PUBLISH_DONOR_UPDATES_CRONTAB

--- a/terraform/core/modules/donor_import/sql_database.tf
+++ b/terraform/core/modules/donor_import/sql_database.tf
@@ -1,3 +1,9 @@
 locals {
-  donor_import_connection_string = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+
+  donor_import_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  )
 }

--- a/terraform/core/modules/donor_import/sql_database.tf
+++ b/terraform/core/modules/donor_import/sql_database.tf
@@ -1,8 +1,8 @@
 locals {
-  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+  external_sql_fqdn = "${var.EXTERNAL_SQL_SERVER_NAME}.database.windows.net"
 
-  donor_import_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  donor_import_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_SHARED};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   )

--- a/terraform/core/modules/donor_import/variables_release.tf
+++ b/terraform/core/modules/donor_import/variables_release.tf
@@ -84,17 +84,17 @@ variable "ALLOW_FULL_MODE_IMPORT" {
 }
 
 // External SQL variables
-variable "use_external_sql" {
+variable "USE_EXTERNAL_SQL" {
   type    = bool
   default = false
 }
 
-variable "external_sql_server_name" {
+variable "EXTERNAL_SQL_SERVER_NAME" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_shared" {
+variable "EXTERNAL_SQL_DB_SHARED" {
   type    = string
   default = ""
 }

--- a/terraform/core/modules/donor_import/variables_release.tf
+++ b/terraform/core/modules/donor_import/variables_release.tf
@@ -82,3 +82,19 @@ variable "FAILURE_LOGS_EXPIRY_IN_DAYS" {
 variable "ALLOW_FULL_MODE_IMPORT" {
   type = bool
 }
+
+// External SQL variables
+variable "use_external_sql" {
+  type    = bool
+  default = false
+}
+
+variable "external_sql_server_name" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_shared" {
+  type    = string
+  default = ""
+}

--- a/terraform/core/modules/match_prediction/container_app.tf
+++ b/terraform/core/modules/match_prediction/container_app.tf
@@ -70,7 +70,7 @@ resource "azurerm_container_app" "atlas_match_prediction" {
         name  = "MessagingServiceBus__SendRetryCount"
         value = tostring(var.SERVICE_BUS_SEND_RETRY_COUNT)
       }
-      
+
       env {
         name  = "MessagingServiceBus__SendRetryCooldownSeconds"
         value = tostring(var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS)

--- a/terraform/core/modules/match_prediction/outputs.tf
+++ b/terraform/core/modules/match_prediction/outputs.tf
@@ -28,8 +28,8 @@ output "service_bus" {
 
 output "container_app" {
   value = {
-    fqdn              = azurerm_container_app.atlas_match_prediction.ingress[0].fqdn
-    name              = azurerm_container_app.atlas_match_prediction.name
-    latest_revision   = azurerm_container_app.atlas_match_prediction.latest_revision_name
+    fqdn            = azurerm_container_app.atlas_match_prediction.ingress[0].fqdn
+    name            = azurerm_container_app.atlas_match_prediction.name
+    latest_revision = azurerm_container_app.atlas_match_prediction.latest_revision_name
   }
 }

--- a/terraform/core/modules/match_prediction/sql_database.tf
+++ b/terraform/core/modules/match_prediction/sql_database.tf
@@ -1,3 +1,9 @@
 locals {
-  match_prediction_database_connection_string = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+
+  match_prediction_database_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  )
 }

--- a/terraform/core/modules/match_prediction/sql_database.tf
+++ b/terraform/core/modules/match_prediction/sql_database.tf
@@ -1,8 +1,8 @@
 locals {
-  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+  external_sql_fqdn = "${var.EXTERNAL_SQL_SERVER_NAME}.database.windows.net"
 
-  match_prediction_database_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  match_prediction_database_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_SHARED};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   )

--- a/terraform/core/modules/match_prediction/variables_release.tf
+++ b/terraform/core/modules/match_prediction/variables_release.tf
@@ -76,3 +76,19 @@ variable "CONTAINER_MAX_REPLICAS" {
   type    = number
   default = 1
 }
+
+// External SQL variables
+variable "use_external_sql" {
+  type    = bool
+  default = false
+}
+
+variable "external_sql_server_name" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_shared" {
+  type    = string
+  default = ""
+}

--- a/terraform/core/modules/match_prediction/variables_release.tf
+++ b/terraform/core/modules/match_prediction/variables_release.tf
@@ -78,17 +78,17 @@ variable "CONTAINER_MAX_REPLICAS" {
 }
 
 // External SQL variables
-variable "use_external_sql" {
+variable "USE_EXTERNAL_SQL" {
   type    = bool
   default = false
 }
 
-variable "external_sql_server_name" {
+variable "EXTERNAL_SQL_SERVER_NAME" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_shared" {
+variable "EXTERNAL_SQL_DB_SHARED" {
   type    = string
   default = ""
 }

--- a/terraform/core/modules/matching_algorithm/donor_management_function.tf
+++ b/terraform/core/modules/matching_algorithm/donor_management_function.tf
@@ -19,11 +19,11 @@ locals {
     "MessagingServiceBus:SendRetryCount"                                                            = var.SERVICE_BUS_SEND_RETRY_COUNT
     "MessagingServiceBus:SendRetryCooldownSeconds"                                                  = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "NotificationsServiceBus:ConnectionString"           = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
-    "NotificationsServiceBus:AlertsTopic"                = var.servicebus_topics.alerts.name
-    "NotificationsServiceBus:NotificationsTopic"         = var.servicebus_topics.notifications.name
-    "NotificationsServiceBus:SendRetryCount"             = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "NotificationsServiceBus:SendRetryCooldownSeconds"   = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "NotificationsServiceBus:ConnectionString"         = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
+    "NotificationsServiceBus:AlertsTopic"              = var.servicebus_topics.alerts.name
+    "NotificationsServiceBus:NotificationsTopic"       = var.servicebus_topics.notifications.name
+    "NotificationsServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "NotificationsServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
     "WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT" = "1"
     "WEBSITE_RUN_FROM_PACKAGE"                  = var.WEBSITE_RUN_FROM_PACKAGE
@@ -87,7 +87,7 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_donor_manageme
   connection_string {
     name  = "DonorSql"
     type  = "SQLAzure"
-    value = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.donor_import_sql_database.name};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    value = local.matching_donor_database_connection_string
   }
 
   lifecycle {

--- a/terraform/core/modules/matching_algorithm/matching_algorithm_function.tf
+++ b/terraform/core/modules/matching_algorithm/matching_algorithm_function.tf
@@ -66,20 +66,20 @@ locals {
     "MessagingServiceBus:SendRetryCount"                 = var.SERVICE_BUS_SEND_RETRY_COUNT
     "MessagingServiceBus:SendRetryCooldownSeconds"       = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "NotificationsServiceBus:ConnectionString"           = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
-    "NotificationsServiceBus:AlertsTopic"                = var.servicebus_topics.alerts.name
-    "NotificationsServiceBus:NotificationsTopic"         = var.servicebus_topics.notifications.name
-    "NotificationsServiceBus:SendRetryCount"             = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "NotificationsServiceBus:SendRetryCooldownSeconds"   = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "NotificationsServiceBus:ConnectionString"         = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
+    "NotificationsServiceBus:AlertsTopic"              = var.servicebus_topics.alerts.name
+    "NotificationsServiceBus:NotificationsTopic"       = var.servicebus_topics.notifications.name
+    "NotificationsServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "NotificationsServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "SearchTrackingServiceBus:ConnectionString"          = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
-    "SearchTrackingServiceBus:SearchTrackingTopic"       = var.servicebus_topics.search_tracking.name
-    "SearchTrackingServiceBus:SendRetryCount"            = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "SearchTrackingServiceBus:SendRetryCooldownSeconds"  = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "SearchTrackingServiceBus:ConnectionString"         = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
+    "SearchTrackingServiceBus:SearchTrackingTopic"      = var.servicebus_topics.search_tracking.name
+    "SearchTrackingServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "SearchTrackingServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
     "Wmda:WmdaFileUri" = var.WMDA_FILE_URL
 
-    "WEBSITE_RUN_FROM_PACKAGE"                           = var.WEBSITE_RUN_FROM_PACKAGE
+    "WEBSITE_RUN_FROM_PACKAGE" = var.WEBSITE_RUN_FROM_PACKAGE
 
     "WEBSITE_PROACTIVE_AUTOHEAL_ENABLED" = false
   }
@@ -147,7 +147,7 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_function" {
   connection_string {
     name  = "DonorSql"
     type  = "SQLAzure"
-    value = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.donor_import_sql_database.name};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    value = local.matching_donor_database_connection_string
   }
 
   lifecycle {

--- a/terraform/core/modules/matching_algorithm/sql_database.tf
+++ b/terraform/core/modules/matching_algorithm/sql_database.tf
@@ -1,7 +1,26 @@
 locals {
-  matching_transient_database_a_connection_string = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${azurerm_mssql_database.atlas-matching-transient-a.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
-  matching_transient_database_b_connection_string = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${azurerm_mssql_database.atlas-matching-transient-b.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
-  matching_persistent_database_connection_string  = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database_shared.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+
+  matching_transient_database_a_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_matching_a};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${azurerm_mssql_database.atlas-matching-transient-a.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
+  )
+  matching_transient_database_b_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_matching_b};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${azurerm_mssql_database.atlas-matching-transient-b.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
+  )
+  matching_persistent_database_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database_shared.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  )
+  matching_donor_database_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.donor_import_sql_database.name};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  )
 }
 
 resource "azurerm_mssql_database" "atlas-matching-transient-a" {

--- a/terraform/core/modules/matching_algorithm/sql_database.tf
+++ b/terraform/core/modules/matching_algorithm/sql_database.tf
@@ -1,23 +1,23 @@
 locals {
-  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+  external_sql_fqdn = "${var.EXTERNAL_SQL_SERVER_NAME}.database.windows.net"
 
-  matching_transient_database_a_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_matching_a};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
+  matching_transient_database_a_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_MATCHING_A};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${azurerm_mssql_database.atlas-matching-transient-a.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
   )
-  matching_transient_database_b_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_matching_b};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
+  matching_transient_database_b_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_MATCHING_B};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${azurerm_mssql_database.atlas-matching-transient-b.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=${var.DATABASE_TRANSIENT_TIMEOUT};"
   )
-  matching_persistent_database_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  matching_persistent_database_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_SHARED};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database_shared.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   )
-  matching_donor_database_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  matching_donor_database_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_SHARED};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.donor_import_sql_database.name};Persist Security Info=False;User ID=${var.DONOR_IMPORT_DATABASE_USERNAME};Password=${var.DONOR_IMPORT_DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   )

--- a/terraform/core/modules/matching_algorithm/variables_release.tf
+++ b/terraform/core/modules/matching_algorithm/variables_release.tf
@@ -145,3 +145,29 @@ variable "SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC" {
   type     = number
   nullable = true
 }
+
+// External SQL variables
+variable "use_external_sql" {
+  type    = bool
+  default = false
+}
+
+variable "external_sql_server_name" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_shared" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_matching_a" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_matching_b" {
+  type    = string
+  default = ""
+}

--- a/terraform/core/modules/matching_algorithm/variables_release.tf
+++ b/terraform/core/modules/matching_algorithm/variables_release.tf
@@ -147,27 +147,27 @@ variable "SEARCH_RELATED_HLA_METADATA_CACHE_SLIDING_EXPIRATION_SEC" {
 }
 
 // External SQL variables
-variable "use_external_sql" {
+variable "USE_EXTERNAL_SQL" {
   type    = bool
   default = false
 }
 
-variable "external_sql_server_name" {
+variable "EXTERNAL_SQL_SERVER_NAME" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_shared" {
+variable "EXTERNAL_SQL_DB_SHARED" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_matching_a" {
+variable "EXTERNAL_SQL_DB_MATCHING_A" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_matching_b" {
+variable "EXTERNAL_SQL_DB_MATCHING_B" {
   type    = string
   default = ""
 }

--- a/terraform/core/modules/repeat_search/sql_database.tf
+++ b/terraform/core/modules/repeat_search/sql_database.tf
@@ -1,3 +1,9 @@
 locals {
-  repeat_search_database_connection_string = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+
+  repeat_search_database_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  )
 }

--- a/terraform/core/modules/repeat_search/sql_database.tf
+++ b/terraform/core/modules/repeat_search/sql_database.tf
@@ -1,8 +1,8 @@
 locals {
-  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+  external_sql_fqdn = "${var.EXTERNAL_SQL_SERVER_NAME}.database.windows.net"
 
-  repeat_search_database_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  repeat_search_database_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_SHARED};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   )

--- a/terraform/core/modules/repeat_search/variables_di.tf
+++ b/terraform/core/modules/repeat_search/variables_di.tf
@@ -83,8 +83,8 @@ variable "servicebus_namespace_authorization_rules" {
 
 variable "servicebus_topics" {
   type = object({
-    alerts        = object({ name = string })
-    notifications = object({ name = string })
+    alerts          = object({ name = string })
+    notifications   = object({ name = string })
     search_tracking = object({ name = string })
   })
 }

--- a/terraform/core/modules/repeat_search/variables_release.tf
+++ b/terraform/core/modules/repeat_search/variables_release.tf
@@ -58,3 +58,19 @@ variable "STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_BATCHSIZE" {
 variable "STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT" {
   type = number
 }
+
+// External SQL variables
+variable "use_external_sql" {
+  type    = bool
+  default = false
+}
+
+variable "external_sql_server_name" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_shared" {
+  type    = string
+  default = ""
+}

--- a/terraform/core/modules/repeat_search/variables_release.tf
+++ b/terraform/core/modules/repeat_search/variables_release.tf
@@ -60,17 +60,17 @@ variable "STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT" {
 }
 
 // External SQL variables
-variable "use_external_sql" {
+variable "USE_EXTERNAL_SQL" {
   type    = bool
   default = false
 }
 
-variable "external_sql_server_name" {
+variable "EXTERNAL_SQL_SERVER_NAME" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_shared" {
+variable "EXTERNAL_SQL_DB_SHARED" {
   type    = string
   default = ""
 }

--- a/terraform/core/modules/search_tracking/function.tf
+++ b/terraform/core/modules/search_tracking/function.tf
@@ -50,7 +50,7 @@ resource "azurerm_windows_function_app" "atlas_search_tracking_function" {
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
 
-    app_scale_limit         = 1
+    app_scale_limit = 1
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.0"

--- a/terraform/core/modules/search_tracking/sql_database.tf
+++ b/terraform/core/modules/search_tracking/sql_database.tf
@@ -1,8 +1,8 @@
 locals {
-  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+  external_sql_fqdn = "${var.EXTERNAL_SQL_SERVER_NAME}.database.windows.net"
 
-  search_tracking_database_connection_string = var.use_external_sql ? (
-    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  search_tracking_database_connection_string = var.USE_EXTERNAL_SQL ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.EXTERNAL_SQL_DB_SHARED};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
     ) : (
     "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
   )

--- a/terraform/core/modules/search_tracking/sql_database.tf
+++ b/terraform/core/modules/search_tracking/sql_database.tf
@@ -1,3 +1,9 @@
 locals {
-  search_tracking_database_connection_string = "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  external_sql_fqdn = "${var.external_sql_server_name}.database.windows.net"
+
+  search_tracking_database_connection_string = var.use_external_sql ? (
+    "Server=tcp:${local.external_sql_fqdn},1433;Initial Catalog=${var.external_sql_db_shared};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+    ) : (
+    "Server=tcp:${var.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.sql_database.name};Persist Security Info=False;User ID=${var.DATABASE_USERNAME};Password=${var.DATABASE_PASSWORD};MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=1800;"
+  )
 }

--- a/terraform/core/modules/search_tracking/variables_release.tf
+++ b/terraform/core/modules/search_tracking/variables_release.tf
@@ -16,3 +16,19 @@ variable "IP_RESTRICTION_SETTINGS" {
   type    = list(string)
   default = []
 }
+
+// External SQL variables
+variable "use_external_sql" {
+  type    = bool
+  default = false
+}
+
+variable "external_sql_server_name" {
+  type    = string
+  default = ""
+}
+
+variable "external_sql_db_shared" {
+  type    = string
+  default = ""
+}

--- a/terraform/core/modules/search_tracking/variables_release.tf
+++ b/terraform/core/modules/search_tracking/variables_release.tf
@@ -18,17 +18,17 @@ variable "IP_RESTRICTION_SETTINGS" {
 }
 
 // External SQL variables
-variable "use_external_sql" {
+variable "USE_EXTERNAL_SQL" {
   type    = bool
   default = false
 }
 
-variable "external_sql_server_name" {
+variable "EXTERNAL_SQL_SERVER_NAME" {
   type    = string
   default = ""
 }
 
-variable "external_sql_db_shared" {
+variable "EXTERNAL_SQL_DB_SHARED" {
   type    = string
   default = ""
 }

--- a/terraform/core/outputs.tf
+++ b/terraform/core/outputs.tf
@@ -68,5 +68,5 @@ output "container_app_environment" {
 
 output "active_sql_source" {
   description = "Indicates whether function apps target Terraform-managed or external SQL."
-  value       = var.use_external_sql ? "external" : "terraform-managed"
+  value       = var.USE_EXTERNAL_SQL ? "external" : "terraform-managed"
 }

--- a/terraform/core/outputs.tf
+++ b/terraform/core/outputs.tf
@@ -65,3 +65,8 @@ output "container_app_environment" {
     name = azurerm_container_app_environment.atlas.name
   }
 }
+
+output "active_sql_source" {
+  description = "Indicates whether function apps target Terraform-managed or external SQL."
+  value       = var.use_external_sql ? "external" : "terraform-managed"
+}

--- a/terraform/core/outputs_ci.tf
+++ b/terraform/core/outputs_ci.tf
@@ -6,7 +6,7 @@ output "donor-database-username" {
 }
 
 output "donor-import-database-name" {
-  value = azurerm_mssql_database.atlas-database-shared.name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_SHARED : azurerm_mssql_database.atlas-database-shared.name
 }
 
 output "donor-import-function-name" {
@@ -22,7 +22,7 @@ output "function-app-name" {
 }
 
 output "match-prediction-database-name" {
-  value = azurerm_mssql_database.atlas-database-shared.name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_SHARED : azurerm_mssql_database.atlas-database-shared.name
 }
 
 output "match-prediction-function-name" {
@@ -34,15 +34,15 @@ output "match-prediction-database-username" {
 }
 
 output "matching-algorithm-database-persistent-name" {
-  value = azurerm_mssql_database.atlas-database-shared.name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_SHARED : azurerm_mssql_database.atlas-database-shared.name
 }
 
 output "matching-algorithm-database-transient-a-name" {
-  value = module.matching_algorithm.sql_database.transient_a_database_name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_MATCHING_A : module.matching_algorithm.sql_database.transient_a_database_name
 }
 
 output "matching-algorithm-database-transient-b-name" {
-  value = module.matching_algorithm.sql_database.transient_b_database_name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_MATCHING_B : module.matching_algorithm.sql_database.transient_b_database_name
 }
 
 output "matching-algorithm-function-name" {
@@ -62,7 +62,7 @@ output "public-api-function-app-name" {
 }
 
 output "repeat-search-database-name" {
-  value = azurerm_mssql_database.atlas-database-shared.name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_SHARED : azurerm_mssql_database.atlas-database-shared.name
 }
 
 output "repeat-search-username" {
@@ -74,7 +74,7 @@ output "repeat-search-function-name" {
 }
 
 output "search-tracking-database-name" {
-  value = azurerm_mssql_database.atlas-database-shared.name
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_DB_SHARED : azurerm_mssql_database.atlas-database-shared.name
 }
 
 output "search-tracking-username" {

--- a/terraform/core/outputs_ci.tf
+++ b/terraform/core/outputs_ci.tf
@@ -86,11 +86,11 @@ output "search-tracking-function-name" {
 }
 
 output "sql-server" {
-  value = azurerm_mssql_server.atlas_sql_server.fully_qualified_domain_name
+  value = var.USE_EXTERNAL_SQL ? "${var.EXTERNAL_SQL_SERVER_NAME}.database.windows.net" : azurerm_mssql_server.atlas_sql_server.fully_qualified_domain_name
 }
 
 output "sql-server-admin-login" {
-  value = var.DATABASE_SERVER_ADMIN_LOGIN
+  value = var.USE_EXTERNAL_SQL ? var.EXTERNAL_SQL_SERVER_ADMIN_LOGIN : var.DATABASE_SERVER_ADMIN_LOGIN
 }
 
 output "sql-server-admin-login-password" {

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -622,3 +622,9 @@ variable "EXTERNAL_SQL_DB_MATCHING_B" {
   type        = string
   default     = ""
 }
+
+variable "EXTERNAL_SQL_SERVER_ADMIN_LOGIN" {
+  description = "Admin login for the external SQL server. Consumed via TF_VAR_EXTERNAL_SQL_SERVER_ADMIN_LOGIN."
+  type        = string
+  default     = ""
+}

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -590,3 +590,40 @@ variable "MATCH_PREDICTION_CONTAINER_MAX_REPLICAS" {
   default     = 1
   description = "Maximum replica count for the match prediction container app."
 }
+
+# --- External SQL variables (for retargeting function app connection strings) ---
+
+variable "use_external_sql" {
+  description = "When true, function app connection strings target an external SQL server instead of the Terraform-managed one."
+  type        = bool
+  default     = false
+}
+
+variable "external_sql_server_name" {
+  description = "Short name of the external Azure SQL server (without .database.windows.net suffix). Consumed via TF_VAR_external_sql_server_name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.use_external_sql ? length(var.external_sql_server_name) > 0 : true
+    error_message = "external_sql_server_name is required when use_external_sql is true."
+  }
+}
+
+variable "external_sql_db_shared" {
+  description = "Name of the external shared (atlas) database. Consumed via TF_VAR_external_sql_db_shared."
+  type        = string
+  default     = ""
+}
+
+variable "external_sql_db_matching_a" {
+  description = "Name of the external matching-a database. Consumed via TF_VAR_external_sql_db_matching_a."
+  type        = string
+  default     = ""
+}
+
+variable "external_sql_db_matching_b" {
+  description = "Name of the external matching-b database. Consumed via TF_VAR_external_sql_db_matching_b."
+  type        = string
+  default     = ""
+}

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -603,11 +603,6 @@ variable "external_sql_server_name" {
   description = "Short name of the external Azure SQL server (without .database.windows.net suffix). Consumed via TF_VAR_external_sql_server_name."
   type        = string
   default     = ""
-
-  validation {
-    condition     = var.use_external_sql ? length(var.external_sql_server_name) > 0 : true
-    error_message = "external_sql_server_name is required when use_external_sql is true."
-  }
 }
 
 variable "external_sql_db_shared" {

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -593,32 +593,32 @@ variable "MATCH_PREDICTION_CONTAINER_MAX_REPLICAS" {
 
 # --- External SQL variables (for retargeting function app connection strings) ---
 
-variable "use_external_sql" {
+variable "USE_EXTERNAL_SQL" {
   description = "When true, function app connection strings target an external SQL server instead of the Terraform-managed one."
   type        = bool
   default     = false
 }
 
-variable "external_sql_server_name" {
-  description = "Short name of the external Azure SQL server (without .database.windows.net suffix). Consumed via TF_VAR_external_sql_server_name."
+variable "EXTERNAL_SQL_SERVER_NAME" {
+  description = "Short name of the external Azure SQL server (without .database.windows.net suffix). Consumed via TF_VAR_EXTERNAL_SQL_SERVER_NAME."
   type        = string
   default     = ""
 }
 
-variable "external_sql_db_shared" {
-  description = "Name of the external shared (atlas) database. Consumed via TF_VAR_external_sql_db_shared."
+variable "EXTERNAL_SQL_DB_SHARED" {
+  description = "Name of the external shared (atlas) database. Consumed via TF_VAR_EXTERNAL_SQL_DB_SHARED."
   type        = string
   default     = ""
 }
 
-variable "external_sql_db_matching_a" {
-  description = "Name of the external matching-a database. Consumed via TF_VAR_external_sql_db_matching_a."
+variable "EXTERNAL_SQL_DB_MATCHING_A" {
+  description = "Name of the external matching-a database. Consumed via TF_VAR_EXTERNAL_SQL_DB_MATCHING_A."
   type        = string
   default     = ""
 }
 
-variable "external_sql_db_matching_b" {
-  description = "Name of the external matching-b database. Consumed via TF_VAR_external_sql_db_matching_b."
+variable "EXTERNAL_SQL_DB_MATCHING_B" {
+  description = "Name of the external matching-b database. Consumed via TF_VAR_EXTERNAL_SQL_DB_MATCHING_B."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Introduce external SQL configuration to allow function apps to connect to an external (not provisioned via Terraform) SQL server.
Update outputs and connection strings to conditionally use the external SQL settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1458)
<!-- Reviewable:end -->
