### PR TITLE
Set Application Insights daily data cap as a variable

### DIFF
--- a/terraform/core/application_insights.tf
+++ b/terraform/core/application_insights.tf
@@ -1,6 +1,6 @@
 resource "azurerm_application_insights" "atlas" {
   application_type     = "web"
-  daily_data_cap_in_gb = 100
+  daily_data_cap_in_gb = var.APPLICATION_INSIGHTS_DAILY_DATA_CAP_IN_GB
   location             = local.location
   name                 = "${local.environment}-ATLAS"
   resource_group_name  = azurerm_resource_group.atlas_resource_group.name

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -4,6 +4,12 @@ variable "APPLICATION_INSIGHTS_LOG_LEVEL" {
   description = "Corresponds to the severity levels defined by application insights. Allowed values: Verbose, Info (maps to Information), Warn (maps to Warning), Error, Critical."
 }
 
+variable "APPLICATION_INSIGHTS_DAILY_DATA_CAP_IN_GB" {
+  type        = number
+  default     = 100
+  description = "Daily data cap in GB for Application Insights. Use TF_VAR_APPLICATION_INSIGHTS_DAILY_DATA_CAP_IN_GB environment variable to override for specific environments."
+}
+
 variable "AZURE_CLIENT_ID" {
   type        = string
   description = "Client ID used for authenticating to manage Azure resources from code."


### PR DESCRIPTION
Introduce a variable for the daily data cap in Application Insights, allowing for easier configuration and environment-specific overrides. Default value remains set at 100 GB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1464)
<!-- Reviewable:end -->
