### PR TITLE
feature: ATL-123: Automate RC branch lifecycle management

### DIFF
--- a/.github/workflows/delete_rc_on_release.yml
+++ b/.github/workflows/delete_rc_on_release.yml
@@ -1,0 +1,33 @@
+# This workflow will:
+# * When a released tag is pushed:
+# * Parse the major/minor version of the tag
+# * Delete any corresponding rc/* branch from origin
+
+name: Delete Deployed Release Candidate Branch
+
+on:
+  push:
+    tags:
+      - 'released/**'
+
+jobs:
+  delete-rc-branch:
+    name: Delete Deployed RC Branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Use third-party tool to parse semver from arbitrarily formatted tag
+      - run: sudo npm install -g semver
+
+      - run: |
+          # Extract semantic version from tag and cut to major.minor
+          majMin=$(semver -c ${{ github.ref }} | cut -f1,2 -d'.')
+
+          echo "Parsed major.minor: $majMin"
+
+          git push origin --delete "rc/$majMin" || true
+          git push origin --delete "rc/$majMin.x" || true

--- a/.github/workflows/post_release_candidate_branch_creation.yml
+++ b/.github/workflows/post_release_candidate_branch_creation.yml
@@ -1,0 +1,40 @@
+# This workflow will:
+# * Identify creation of (but not updates to) release candidate branches, as denoted by `rc/*`
+# * Bump the minor version of the service on the *master* branch
+
+name: Post Release Candidate Branch Creation
+
+on:
+  # Runs on create of *any* branch. See https://github.community/t/trigger-job-on-branch-created/16878/5 - cannot currently trigger on create and filter by branch.
+  # We can either manually filter, or only trigger on push - and we don't want to bump the version every time we push to an rc branch!
+  create:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    name: Post Release Candidate Branch Creation
+    # Only run if *creating* an rc branch (excludes hotfix/* and all other branches)
+    if: ${{ contains(github.ref, 'refs/heads/rc/') }}
+    # Must run on windows - npm package used to bump version does not work on Ubuntu. https://github.com/vweevers/dotnet-bump/issues/1
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # By default, will checkout the pushed branch. We want to bump the version on *master*
+          ref: 'master'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm install -g dotnet-bump
+
+      # Cannot push without identification
+      - run: git config --global user.email ${{ github.actor }}
+      - run: git config --global user.name ${{ github.actor }}
+
+      # Note that dotnet-bump commits and tags. Tags are not pushed here as we don't want a version tag at this point.
+      - run: dotnet-bump minor
+      - run: git push


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that auto-bumps the **minor version on `master`** whenever an `rc/*` branch is created, using the `dotnet-bump` npm package
- Adds a GitHub Actions workflow that **deletes the corresponding `rc/*` branch** when a `released/**` tag is pushed, keeping the branch list clean after a production release

## Test plan

- [ ] Create an `rc/<version>` branch and verify the minor version is bumped on `master` via the _Post Release Candidate Branch Creation_ workflow
- [ ] Push a `released/<version>` tag and verify the corresponding `rc/<major.minor>` branch is deleted via the _Delete Deployed Release Candidate Branch_ workflow
- [ ] Verify non-`rc/*` branch creation does not trigger the version bump workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1469)
<!-- Reviewable:end -->
