### PR TITLE
feature: ATL-128: finalise all parallel match-prediction runs after r…

### DIFF
--- a/Atlas.Functions/Functions/ParallelMatchPredictionAggregatorFunctions.cs
+++ b/Atlas.Functions/Functions/ParallelMatchPredictionAggregatorFunctions.cs
@@ -161,11 +161,14 @@ public class ParallelMatchPredictionAggregatorFunctions
     }
 
     /// <summary>
-    /// Timer-triggered clean-up. Deletes per-batch rows belonging to runs that finalised more than
-    /// <c>ParallelBatchRetentionDays</c> ago and marks those runs as
-    /// <see cref="Atlas.MatchPrediction.Data.Models.ParallelMatchPredictionRunStatus.FinalisedAndCleanedUp"/>.
-    /// The parent <c>ParallelMatchPredictionRun</c> rows are kept indefinitely so historic searches remain visible
-    /// in dashboards/audits.
+    /// Timer-triggered clean-up. Deletes per-batch rows belonging to <em>any</em> run that has been in the
+    /// database for more than <c>ParallelBatchRetentionDays</c> (measured from <c>MatchPredictionRunInitiatedUtc</c>),
+    /// regardless of status — this includes abandoned runs still in
+    /// <see cref="Atlas.MatchPrediction.Data.Models.ParallelMatchPredictionRunStatus.Running"/>,
+    /// finalised runs, and failed runs — and marks each such run with
+    /// <see cref="Atlas.MatchPrediction.Data.Models.ParallelMatchPredictionRun.IsCleanedUp"/> = <c>true</c>.
+    /// The run's <c>Status</c> is left unchanged. The parent <c>ParallelMatchPredictionRun</c> rows are kept
+    /// indefinitely so historic searches remain visible in dashboards/audits.
     /// </summary>
     [Function(nameof(CleanupOldParallelMatchPredictionBatches))]
     public async Task CleanupOldParallelMatchPredictionBatches(
@@ -173,9 +176,9 @@ public class ParallelMatchPredictionAggregatorFunctions
         TimerInfo timer)
     {
         var cutoffDate = DateTime.UtcNow.AddDays(-retentionDays);
-        var deletedBatchesCount = await repository.CleanupBatchesForRunsFinalisedBefore(cutoffDate);
+        var deletedBatchesCount = await repository.CleanupBatchesForRunsCreatedBefore(cutoffDate);
         logger.LogInformation(
-            "Parallel match prediction batch cleanup deleted {Count} batch row(s) finalised before {Cutoff:o} (retention {Days} day(s)) and marked their parent runs as cleaned up.",
+            "Parallel match prediction batch cleanup deleted {Count} batch row(s) for runs created before {Cutoff:o} (retention {Days} day(s)) and marked their parent runs as IsCleanedUp.",
             deletedBatchesCount, cutoffDate, retentionDays
         );
     }

--- a/Atlas.Functions/Functions/ParallelMatchPredictionAggregatorFunctions.cs
+++ b/Atlas.Functions/Functions/ParallelMatchPredictionAggregatorFunctions.cs
@@ -176,9 +176,9 @@ public class ParallelMatchPredictionAggregatorFunctions
         TimerInfo timer)
     {
         var cutoffDate = DateTime.UtcNow.AddDays(-retentionDays);
-        var deletedBatchesCount = await repository.CleanupBatchesForRunsCreatedBefore(cutoffDate);
+        var deletedBatchesCount = await repository.CleanupBatchesForRunsInitiatedBefore(cutoffDate);
         logger.LogInformation(
-            "Parallel match prediction batch cleanup deleted {Count} batch row(s) for runs created before {Cutoff:o} (retention {Days} day(s)) and marked their parent runs as IsCleanedUp.",
+            "Parallel match prediction batch cleanup deleted {Count} batch row(s) for runs initiated before {Cutoff:o} (retention {Days} day(s)) and marked their parent runs as cleaned up (IsCleanedUp=true).",
             deletedBatchesCount, cutoffDate, retentionDays
         );
     }

--- a/Atlas.MatchPrediction.Data/Context/MatchPredictionContext.cs
+++ b/Atlas.MatchPrediction.Data/Context/MatchPredictionContext.cs
@@ -28,6 +28,11 @@ public class MatchPredictionContext : DbContext
             .Property(x => x.Status)
             .HasConversion<string>();
 
+        modelBuilder.Entity<ParallelMatchPredictionRun>()
+            .HasIndex(x => x.Status)
+            .HasDatabaseName("IX_ParallelMatchPredictionRuns_Status_Running")
+            .HasFilter("[Status] = 'Running'");
+
         modelBuilder.Entity<ParallelMatchPredictionBatch>()
             .Property(x => x.BatchStatus)
             .HasConversion<string>()

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.Designer.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.MatchPrediction.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.MatchPrediction.Data.Migrations
 {
     [DbContext(typeof(MatchPredictionContext))]
-    partial class MatchPredictionContextModelSnapshot : ModelSnapshot
+    [Migration("20260701130949_AddIsCleanedUpToParallelMatchPredictionRun")]
+    partial class AddIsCleanedUpToParallelMatchPredictionRun
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.Designer.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.Designer.cs
@@ -231,7 +231,9 @@ namespace Atlas.MatchPrediction.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Status");
+                    b.HasIndex("Status")
+                        .HasDatabaseName("IX_ParallelMatchPredictionRuns_Status_Running")
+                        .HasFilter("[Status] = 'Running'");
 
                     b.HasIndex("IsCleanedUp", "MatchPredictionRunInitiatedUtc");
 

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
@@ -25,9 +25,16 @@ namespace Atlas.MatchPrediction.Data.Migrations
 
             // Migrate legacy FinalisedAndCleanedUp rows: restore Status to Finalised and mark IsCleanedUp.
             // FinalisedAndCleanedUp has been removed from the enum; Status is stored as nvarchar.
+            // StatusDateUtc is realigned to FinalisedTimeUtc: under the new model the cleanup step no longer
+            // touches Status/StatusDateUtc, so a finalised-and-cleaned run's StatusDateUtc equals its
+            // finalisation moment. The legacy rows instead carried the cleanup time, which would leave the
+            // (Status='Finalised', StatusDateUtc) pair inconsistent. COALESCE keeps the existing value on the
+            // (not expected) chance FinalisedTimeUtc is null.
             migrationBuilder.Sql(@"
                 UPDATE [MatchPrediction].[ParallelMatchPredictionRuns]
-                SET [IsCleanedUp] = 1, [Status] = 'Finalised'
+                SET [IsCleanedUp] = 1,
+                    [Status] = 'Finalised',
+                    [StatusDateUtc] = COALESCE([FinalisedTimeUtc], [StatusDateUtc])
                 WHERE [Status] = 'FinalisedAndCleanedUp'
             ");
 
@@ -57,15 +64,17 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 schema: "MatchPrediction",
                 table: "ParallelMatchPredictionRuns");
 
-            // Best-effort restore of the legacy status before the IsCleanedUp column is dropped, so older
-            // code that still expects FinalisedAndCleanedUp does not misread these historical rows.
-            // In the pre-migration world a finalised-and-cleaned run *was* FinalisedAndCleanedUp, so mapping
-            // (Finalised + IsCleanedUp) back to that value is the faithful inverse. Cleaned-up rows in other
-            // statuses (failed/abandoned) had no equivalent legacy value and are left as-is.
+            // Restore the pre-migration invariant "no batch rows implies FinalisedAndCleanedUp" before the
+            // IsCleanedUp column is dropped. Mapping cleaned-up Finalised rows back is the faithful inverse;
+            // mapping cleaned-up Running rows is a correctness fix — old code's finalisation query treats a
+            // batch-less Running run as ready (All(...) over an empty set is vacuously true) and would
+            // reprocess it. Failed runs are left as-is: terminal and never re-queried. StatusDateUtc is
+            // stamped with the rollback time, the moment this status change happens.
             migrationBuilder.Sql(@"
                 UPDATE [MatchPrediction].[ParallelMatchPredictionRuns]
-                SET [Status] = 'FinalisedAndCleanedUp'
-                WHERE [Status] = 'Finalised' AND [IsCleanedUp] = 1
+                SET [Status] = 'FinalisedAndCleanedUp',
+                    [StatusDateUtc] = SYSUTCDATETIME()
+                WHERE ([Status] = 'Finalised' OR [Status] = 'Running') AND [IsCleanedUp] = 1
             ");
 
             migrationBuilder.DropColumn(

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
@@ -30,10 +30,11 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 columns: new[] { "IsCleanedUp", "MatchPredictionRunInitiatedUtc" });
 
             migrationBuilder.CreateIndex(
-                name: "IX_ParallelMatchPredictionRuns_Status",
+                name: "IX_ParallelMatchPredictionRuns_Status_Running",
                 schema: "MatchPrediction",
                 table: "ParallelMatchPredictionRuns",
-                column: "Status");
+                column: "Status",
+                filter: "[Status] = 'Running'");
         }
 
         /// <inheritdoc />
@@ -45,7 +46,7 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 table: "ParallelMatchPredictionRuns");
 
             migrationBuilder.DropIndex(
-                name: "IX_ParallelMatchPredictionRuns_Status",
+                name: "IX_ParallelMatchPredictionRuns_Status_Running",
                 schema: "MatchPrediction",
                 table: "ParallelMatchPredictionRuns");
 

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.MatchPrediction.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsCleanedUpToParallelMatchPredictionRun : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ParallelMatchPredictionRuns_Status_FinalisedTimeUtc",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCleanedUp",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            // Migrate legacy FinalisedAndCleanedUp rows: restore Status to Finalised and mark IsCleanedUp.
+            // FinalisedAndCleanedUp has been removed from the enum; Status is stored as nvarchar.
+            migrationBuilder.Sql(@"
+                UPDATE [MatchPrediction].[ParallelMatchPredictionRuns]
+                SET [IsCleanedUp] = 1, [Status] = 'Finalised'
+                WHERE [Status] = 'FinalisedAndCleanedUp'
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ParallelMatchPredictionRuns_IsCleanedUp_MatchPredictionRunInitiatedUtc",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns",
+                columns: new[] { "IsCleanedUp", "MatchPredictionRunInitiatedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ParallelMatchPredictionRuns_Status",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ParallelMatchPredictionRuns_IsCleanedUp_MatchPredictionRunInitiatedUtc",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ParallelMatchPredictionRuns_Status",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns");
+
+            migrationBuilder.DropColumn(
+                name: "IsCleanedUp",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ParallelMatchPredictionRuns_Status_FinalisedTimeUtc",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionRuns",
+                columns: new[] { "Status", "FinalisedTimeUtc" });
+        }
+    }
+}

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
@@ -57,6 +57,17 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 schema: "MatchPrediction",
                 table: "ParallelMatchPredictionRuns");
 
+            // Best-effort restore of the legacy status before the IsCleanedUp column is dropped, so older
+            // code that still expects FinalisedAndCleanedUp does not misread these historical rows.
+            // In the pre-migration world a finalised-and-cleaned run *was* FinalisedAndCleanedUp, so mapping
+            // (Finalised + IsCleanedUp) back to that value is the faithful inverse. Cleaned-up rows in other
+            // statuses (failed/abandoned) had no equivalent legacy value and are left as-is.
+            migrationBuilder.Sql(@"
+                UPDATE [MatchPrediction].[ParallelMatchPredictionRuns]
+                SET [Status] = 'FinalisedAndCleanedUp'
+                WHERE [Status] = 'Finalised' AND [IsCleanedUp] = 1
+            ");
+
             migrationBuilder.DropColumn(
                 name: "IsCleanedUp",
                 schema: "MatchPrediction",

--- a/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260701130949_AddIsCleanedUpToParallelMatchPredictionRun.cs
@@ -23,21 +23,6 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 nullable: false,
                 defaultValue: false);
 
-            // Migrate legacy FinalisedAndCleanedUp rows: restore Status to Finalised and mark IsCleanedUp.
-            // FinalisedAndCleanedUp has been removed from the enum; Status is stored as nvarchar.
-            // StatusDateUtc is realigned to FinalisedTimeUtc: under the new model the cleanup step no longer
-            // touches Status/StatusDateUtc, so a finalised-and-cleaned run's StatusDateUtc equals its
-            // finalisation moment. The legacy rows instead carried the cleanup time, which would leave the
-            // (Status='Finalised', StatusDateUtc) pair inconsistent. COALESCE keeps the existing value on the
-            // (not expected) chance FinalisedTimeUtc is null.
-            migrationBuilder.Sql(@"
-                UPDATE [MatchPrediction].[ParallelMatchPredictionRuns]
-                SET [IsCleanedUp] = 1,
-                    [Status] = 'Finalised',
-                    [StatusDateUtc] = COALESCE([FinalisedTimeUtc], [StatusDateUtc])
-                WHERE [Status] = 'FinalisedAndCleanedUp'
-            ");
-
             migrationBuilder.CreateIndex(
                 name: "IX_ParallelMatchPredictionRuns_IsCleanedUp_MatchPredictionRunInitiatedUtc",
                 schema: "MatchPrediction",
@@ -63,19 +48,6 @@ namespace Atlas.MatchPrediction.Data.Migrations
                 name: "IX_ParallelMatchPredictionRuns_Status",
                 schema: "MatchPrediction",
                 table: "ParallelMatchPredictionRuns");
-
-            // Restore the pre-migration invariant "no batch rows implies FinalisedAndCleanedUp" before the
-            // IsCleanedUp column is dropped. Mapping cleaned-up Finalised rows back is the faithful inverse;
-            // mapping cleaned-up Running rows is a correctness fix — old code's finalisation query treats a
-            // batch-less Running run as ready (All(...) over an empty set is vacuously true) and would
-            // reprocess it. Failed runs are left as-is: terminal and never re-queried. StatusDateUtc is
-            // stamped with the rollback time, the moment this status change happens.
-            migrationBuilder.Sql(@"
-                UPDATE [MatchPrediction].[ParallelMatchPredictionRuns]
-                SET [Status] = 'FinalisedAndCleanedUp',
-                    [StatusDateUtc] = SYSUTCDATETIME()
-                WHERE ([Status] = 'Finalised' OR [Status] = 'Running') AND [IsCleanedUp] = 1
-            ");
 
             migrationBuilder.DropColumn(
                 name: "IsCleanedUp",

--- a/Atlas.MatchPrediction.Data/Migrations/MatchPredictionContextModelSnapshot.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/MatchPredictionContextModelSnapshot.cs
@@ -228,7 +228,9 @@ namespace Atlas.MatchPrediction.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Status");
+                    b.HasIndex("Status")
+                        .HasDatabaseName("IX_ParallelMatchPredictionRuns_Status_Running")
+                        .HasFilter("[Status] = 'Running'");
 
                     b.HasIndex("IsCleanedUp", "MatchPredictionRunInitiatedUtc");
 

--- a/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionRun.cs
@@ -11,7 +11,6 @@ namespace Atlas.MatchPrediction.Data.Models;
 /// historic searches remain visible even after their per-batch detail rows have been purged.
 /// </summary>
 [Index(nameof(IsCleanedUp), nameof(MatchPredictionRunInitiatedUtc))]
-[Index(nameof(Status))]
 public class ParallelMatchPredictionRun
 {
     [Key]

--- a/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionRun.cs
+++ b/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionRun.cs
@@ -10,7 +10,8 @@ namespace Atlas.MatchPrediction.Data.Models;
 /// One row per <c>SearchRequest</c> on the parallel path. Survives the batch clean-up so that
 /// historic searches remain visible even after their per-batch detail rows have been purged.
 /// </summary>
-[Index(nameof(Status), nameof(FinalisedTimeUtc))]
+[Index(nameof(IsCleanedUp), nameof(MatchPredictionRunInitiatedUtc))]
+[Index(nameof(Status))]
 public class ParallelMatchPredictionRun
 {
     [Key]
@@ -99,6 +100,14 @@ public class ParallelMatchPredictionRun
     /// <c>true</c> when every batch succeeded; <c>false</c> when at least one batch failed.
     /// </summary>
     public bool? IsSuccessful { get; set; }
+
+    /// <summary>
+    /// Whether this run's per-batch detail rows have been purged by the retention clean-up.
+    /// Tracked independently of <see cref="Status"/> so that a run keeps its outcome status
+    /// (e.g. <see cref="ParallelMatchPredictionRunStatus.Finalised"/> or a failed/abandoned state)
+    /// while still being recorded as cleaned up. 
+    /// </summary>
+    public bool IsCleanedUp { get; set; }
 
     public ICollection<ParallelMatchPredictionBatch> Batches { get; set; }
 }

--- a/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionRunStatus.cs
+++ b/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionRunStatus.cs
@@ -15,12 +15,6 @@ public enum ParallelMatchPredictionRunStatus
     Finalised,
 
     /// <summary>
-    /// The run has been finalised and its per-batch rows have been deleted after the retention period.
-    /// The parent run row itself is kept indefinitely for audit purposes.
-    /// </summary>
-    FinalisedAndCleanedUp,
-
-    /// <summary>
     /// The persistence pipeline threw while finalising this run. The run is terminal — it will not be
     /// re-picked by the finaliser timer. Per-batch rows remain in place for audit/debugging.
     /// </summary>

--- a/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
+++ b/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
@@ -120,14 +120,18 @@ public interface IParallelMatchPredictionRepository
     Task MarkRunFailedDuringCompletion(int runId, DateTime nowUtc);
 
     /// <summary>
-    /// Deletes batch rows belonging to runs that have status <see cref="ParallelMatchPredictionRunStatus.Finalised"/>
-    /// and whose <c>FinalisedTimeUtc</c> is before <paramref name="cutoffUtc"/>, then marks those runs as
-    /// <see cref="ParallelMatchPredictionRunStatus.FinalisedAndCleanedUp"/>. The whole operation is wrapped in a
-    /// transaction so that the status update and batch deletion are atomic.
+    /// Deletes batch rows belonging to runs that have not yet been cleaned up
+    /// (<see cref="ParallelMatchPredictionRun.IsCleanedUp"/> is <c>false</c>) and whose
+    /// <c>MatchPredictionRunInitiatedUtc</c> is before <paramref name="cutoffUtc"/> — i.e. every run that has
+    /// been in the database longer than the retention period, regardless of status (including abandoned
+    /// <see cref="ParallelMatchPredictionRunStatus.Running"/> runs and failed runs). Marks those runs as
+    /// cleaned up by setting <see cref="ParallelMatchPredictionRun.IsCleanedUp"/> to <c>true</c>; the run's
+    /// <see cref="ParallelMatchPredictionRun.Status"/> is left unchanged so it remains a historical record.
+    /// The whole operation is wrapped in a transaction so that the flag update and batch deletion are atomic.
     /// Parent run rows are intentionally retained.
     /// </summary>
     /// <returns>The number of batch rows deleted.</returns>
-    Task<int> CleanupBatchesForRunsFinalisedBefore(DateTime cutoffUtc);
+    Task<int> CleanupBatchesForRunsCreatedBefore(DateTime cutoffUtc);
 }
 
 public class ParallelMatchPredictionRepository : IParallelMatchPredictionRepository
@@ -272,6 +276,7 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             .AsNoTracking()
             .Where(r => r.Status == ParallelMatchPredictionRunStatus.Running
                      && r.FinalisationLeaseOwner == null
+                     && !r.IsCleanedUp
                      && r.Batches.All(b => b.BatchStatus != ParallelMatchPredictionBatchStatus.Requested)
             )
             .Select(r => r.Id)
@@ -284,6 +289,7 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             .Where(r => r.Id == runId
                      && r.Status == ParallelMatchPredictionRunStatus.Running
                      && r.FinalisationLeaseOwner == null
+                     && !r.IsCleanedUp
             )
             .ExecuteUpdateAsync(s => s
                 .SetProperty(r => r.FinalisationLeaseOwner, leaseOwner)
@@ -357,12 +363,14 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             );
     }
 
-    public async Task<int> CleanupBatchesForRunsFinalisedBefore(DateTime cutoffUtc)
+    public async Task<int> CleanupBatchesForRunsCreatedBefore(DateTime cutoffUtc)
     {
+        // Every run that has been in the database longer than the retention period and has not already
+        // been cleaned up, regardless of status (Finalised, failed, or abandoned while still Running).
         var runIds = await context.ParallelMatchPredictionRuns
             .AsNoTracking()
-            .Where(r => r.Status == ParallelMatchPredictionRunStatus.Finalised
-                     && r.FinalisedTimeUtc < cutoffUtc
+            .Where(r => !r.IsCleanedUp
+                     && r.MatchPredictionRunInitiatedUtc < cutoffUtc
             )
             .Select(r => r.Id)
             .ToListAsync();
@@ -372,19 +380,18 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             return 0;
         }
 
-        // Use a transaction so the batch deletion and the parent-status update are atomic.
+        // Use a transaction so the batch deletion and the parent-run flag update are atomic.
         await using var transaction = await context.Database.BeginTransactionAsync();
 
         var deletedBatchCount = await context.ParallelMatchPredictionBatches
             .Where(b => runIds.Contains(b.RunId))
             .ExecuteDeleteAsync();
 
-        var now = DateTime.UtcNow;
+        // Mark the runs as cleaned up. Status is intentionally left unchanged so the run keeps its outcome.
         await context.ParallelMatchPredictionRuns
             .Where(r => runIds.Contains(r.Id))
             .ExecuteUpdateAsync(s => s
-                .SetProperty(r => r.Status, ParallelMatchPredictionRunStatus.FinalisedAndCleanedUp)
-                .SetProperty(r => r.StatusDateUtc, now)
+                .SetProperty(r => r.IsCleanedUp, true)
             );
 
         await transaction.CommitAsync();

--- a/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
+++ b/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
@@ -367,29 +367,20 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
     {
         // Every run that has been in the database longer than the retention period and has not already
         // been cleaned up, regardless of status (Finalised, failed, or abandoned while still Running).
-        var runIds = await context.ParallelMatchPredictionRuns
-            .AsNoTracking()
+        var runsToClean = context.ParallelMatchPredictionRuns
             .Where(r => !r.IsCleanedUp
                      && r.MatchPredictionRunInitiatedUtc < cutoffUtc
-            )
-            .Select(r => r.Id)
-            .ToListAsync();
-
-        if (runIds.Count == 0)
-        {
-            return 0;
-        }
+            );
 
         // Use a transaction so the batch deletion and the parent-run flag update are atomic.
         await using var transaction = await context.Database.BeginTransactionAsync();
-
+       
         var deletedBatchCount = await context.ParallelMatchPredictionBatches
-            .Where(b => runIds.Contains(b.RunId))
+            .Where(b => runsToClean.Any(r => r.Id == b.RunId))
             .ExecuteDeleteAsync();
 
         // Mark the runs as cleaned up. Status is intentionally left unchanged so the run keeps its outcome.
-        await context.ParallelMatchPredictionRuns
-            .Where(r => runIds.Contains(r.Id))
+        await runsToClean
             .ExecuteUpdateAsync(s => s
                 .SetProperty(r => r.IsCleanedUp, true)
             );

--- a/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
+++ b/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
@@ -131,7 +131,7 @@ public interface IParallelMatchPredictionRepository
     /// Parent run rows are intentionally retained.
     /// </summary>
     /// <returns>The number of batch rows deleted.</returns>
-    Task<int> CleanupBatchesForRunsCreatedBefore(DateTime cutoffUtc);
+    Task<int> CleanupBatchesForRunsInitiatedBefore(DateTime cutoffUtc);
 }
 
 public class ParallelMatchPredictionRepository : IParallelMatchPredictionRepository
@@ -363,13 +363,19 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             );
     }
 
-    public async Task<int> CleanupBatchesForRunsCreatedBefore(DateTime cutoffUtc)
+    public async Task<int> CleanupBatchesForRunsInitiatedBefore(DateTime cutoffUtc)
     {
         // Every run that has been in the database longer than the retention period and has not already
         // been cleaned up, regardless of status (Finalised, failed, or abandoned while still Running).
+        // A Running run currently claimed for finalisation (FinalisationLeaseOwner set) is excluded:
+        // deleting its batches mid-flight would let the completion pipeline read an empty batch set and
+        // wrongly finalise the run as successful. Together with the single transaction below and the
+        // !IsCleanedUp guard on TryClaimFinalisationLease this closes the race - a claimed run is skipped,
+        // and an unclaimed run cleaned here can no longer be claimed afterwards.
         var runsToClean = context.ParallelMatchPredictionRuns
             .Where(r => !r.IsCleanedUp
                      && r.MatchPredictionRunInitiatedUtc < cutoffUtc
+                     && (r.Status != ParallelMatchPredictionRunStatus.Running || r.FinalisationLeaseOwner == null)
             );
 
         // Use a transaction so the batch deletion and the parent-run flag update are atomic.

--- a/Atlas.MatchPrediction.Test.Integration/IntegrationTests/Repository/ParallelMatchPredictionRepositoryTests.cs
+++ b/Atlas.MatchPrediction.Test.Integration/IntegrationTests/Repository/ParallelMatchPredictionRepositoryTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Atlas.Common.Test.SharedTestHelpers;
+using Atlas.MatchPrediction.Data.Context;
+using Atlas.MatchPrediction.Data.Models;
+using Atlas.MatchPrediction.Data.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Atlas.MatchPrediction.Test.Integration.IntegrationTests.Repository
+{
+    /// <summary>
+    /// Covers the retention clean-up semantics of <see cref="IParallelMatchPredictionRepository.CleanupBatchesForRunsInitiatedBefore"/>:
+    /// runs are cleaned regardless of status once older than the cutoff, their batch rows are deleted and
+    /// <see cref="ParallelMatchPredictionRun.IsCleanedUp"/> is set, an in-flight (leased) finalisation is skipped,
+    /// and cleaned-up runs are excluded from the finalisation queries.
+    /// </summary>
+    [TestFixture]
+    public class ParallelMatchPredictionRepositoryTests
+    {
+        private IParallelMatchPredictionRepository repository;
+        private MatchPredictionContext context;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            TestStackTraceHelper.CatchAndRethrowWithStackTraceInExceptionMessage(() =>
+            {
+                // The shared DI-registered context enables retry-on-failure (via the design-time ContextFactory),
+                // whose execution strategy forbids the user-initiated transactions this repository uses. Build a
+                // dedicated no-retry context here — matching production (Atlas.Functions/Startup.cs) — so those
+                // transactions run, without changing the shared context other integration tests depend on.
+                var connectionString = DependencyInjection.DependencyInjection.Provider
+                    .GetService<MatchPredictionContext>().Database.GetConnectionString();
+                var options = new DbContextOptionsBuilder<MatchPredictionContext>()
+                    .UseSqlServer(connectionString)
+                    .Options;
+                context = new MatchPredictionContext(options);
+                repository = new ParallelMatchPredictionRepository(context);
+            });
+        }
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            // The global DB reset does not touch the parallel tables, so isolate each test explicitly.
+            // Delete batches before runs to respect the FK, and clear the tracker so entities created by
+            // CreateRun in a prior test do not linger in the shared scoped context.
+            context.ChangeTracker.Clear();
+            await context.ParallelMatchPredictionBatches.ExecuteDeleteAsync();
+            await context.ParallelMatchPredictionRuns.ExecuteDeleteAsync();
+        }
+
+        [Test]
+        public async Task CleanupBatchesForRunsInitiatedBefore_DeletesBatchesAndFlagsRun_WhenInitiatedBeforeCutoff()
+        {
+            var cutoff = DateTime.UtcNow;
+            var runId = await CreateRunInitiatedAt(cutoff.AddDays(-1), batchCount: 3);
+
+            var deletedCount = await repository.CleanupBatchesForRunsInitiatedBefore(cutoff);
+
+            deletedCount.Should().Be(3);
+            (await RemainingBatchCountFor(runId)).Should().Be(0);
+            (await IsCleanedUp(runId)).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task CleanupBatchesForRunsInitiatedBefore_LeavesRunsInitiatedOnOrAfterCutoff()
+        {
+            var cutoff = DateTime.UtcNow;
+            var recentRunId = await CreateRunInitiatedAt(cutoff.AddDays(1), batchCount: 2);
+
+            var deletedCount = await repository.CleanupBatchesForRunsInitiatedBefore(cutoff);
+
+            deletedCount.Should().Be(0);
+            (await RemainingBatchCountFor(recentRunId)).Should().Be(2);
+            (await IsCleanedUp(recentRunId)).Should().BeFalse();
+        }
+
+        [Test]
+        public async Task CleanupBatchesForRunsInitiatedBefore_CleansRunsRegardlessOfStatus()
+        {
+            var cutoff = DateTime.UtcNow;
+            var initiatedAt = cutoff.AddDays(-1);
+
+            var abandonedRunningId = await CreateRunInitiatedAt(initiatedAt, batchCount: 1, status: ParallelMatchPredictionRunStatus.Running);
+            var finalisedId = await CreateRunInitiatedAt(initiatedAt, batchCount: 1, status: ParallelMatchPredictionRunStatus.Finalised);
+            var failedBatchId = await CreateRunInitiatedAt(initiatedAt, batchCount: 1, status: ParallelMatchPredictionRunStatus.FailedDuringBatchProcessing);
+            var failedCompletionId = await CreateRunInitiatedAt(initiatedAt, batchCount: 1, status: ParallelMatchPredictionRunStatus.FailedDuringCompletion);
+
+            var deletedCount = await repository.CleanupBatchesForRunsInitiatedBefore(cutoff);
+
+            deletedCount.Should().Be(4);
+            foreach (var runId in new[] { abandonedRunningId, finalisedId, failedBatchId, failedCompletionId })
+            {
+                (await RemainingBatchCountFor(runId)).Should().Be(0);
+                (await IsCleanedUp(runId)).Should().BeTrue();
+            }
+        }
+
+        [Test]
+        public async Task CleanupBatchesForRunsInitiatedBefore_SkipsRunningRunClaimedForFinalisation()
+        {
+            var cutoff = DateTime.UtcNow;
+            var leasedRunId = await CreateRunInitiatedAt(
+                cutoff.AddDays(-1),
+                batchCount: 2,
+                status: ParallelMatchPredictionRunStatus.Running,
+                finalisationLeaseOwner: Guid.NewGuid());
+
+            var deletedCount = await repository.CleanupBatchesForRunsInitiatedBefore(cutoff);
+
+            // A Running run currently being finalised must not have its batches pulled out from under the
+            // completion pipeline.
+            deletedCount.Should().Be(0);
+            (await RemainingBatchCountFor(leasedRunId)).Should().Be(2);
+            (await IsCleanedUp(leasedRunId)).Should().BeFalse();
+        }
+
+        [Test]
+        public async Task GetRunIdsAwaitingFinalisationAndNotLeased_ExcludesCleanedUpRuns()
+        {
+            // Two runs identical in every way that matters to the finalisation query (Running, unleased,
+            // every batch past Requested); one has already been cleaned up and must be skipped.
+            var eligibleRunId = await CreateFinalisationReadyRun();
+            var cleanedUpRunId = await CreateFinalisationReadyRun();
+            await context.ParallelMatchPredictionRuns
+                .Where(r => r.Id == cleanedUpRunId)
+                .ExecuteUpdateAsync(s => s.SetProperty(r => r.IsCleanedUp, true));
+
+            var awaiting = await repository.GetRunIdsAwaitingFinalisationAndNotLeased();
+
+            awaiting.Should().Contain(eligibleRunId);
+            awaiting.Should().NotContain(cleanedUpRunId);
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────────────────
+
+        private async Task<int> CreateRunInitiatedAt(
+            DateTime initiatedUtc,
+            int batchCount,
+            ParallelMatchPredictionRunStatus status = ParallelMatchPredictionRunStatus.Running,
+            Guid? finalisationLeaseOwner = null)
+        {
+            var runId = await repository.CreateRun(new CreateParallelMatchPredictionRunInfo(
+                SearchIdentifier: Guid.NewGuid(),
+                IsRepeatSearch: false,
+                RepeatSearchIdentifier: null,
+                ResultsFileName: "results.json",
+                ResultsBatched: false,
+                BatchFolderName: null,
+                MatchingAlgorithmElapsedTime: TimeSpan.FromSeconds(1),
+                SearchInitiatedTimeUtc: initiatedUtc,
+                TotalBatchCount: batchCount));
+
+            // CreateRun stamps MatchPredictionRunInitiatedUtc with 'now' and status Running; override to
+            // position the run relative to the cutoff and to exercise the status-agnostic behaviour.
+            await context.ParallelMatchPredictionRuns
+                .Where(r => r.Id == runId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.MatchPredictionRunInitiatedUtc, initiatedUtc)
+                    .SetProperty(r => r.Status, status)
+                    .SetProperty(r => r.FinalisationLeaseOwner, finalisationLeaseOwner));
+
+            return runId;
+        }
+
+        private async Task<int> CreateFinalisationReadyRun()
+        {
+            var runId = await CreateRunInitiatedAt(DateTime.UtcNow, batchCount: 1, status: ParallelMatchPredictionRunStatus.Running);
+            await context.ParallelMatchPredictionBatches
+                .Where(b => b.RunId == runId)
+                .ExecuteUpdateAsync(s => s.SetProperty(b => b.BatchStatus, ParallelMatchPredictionBatchStatus.ResultsReceived));
+            return runId;
+        }
+
+        private async Task<int> RemainingBatchCountFor(int runId) =>
+            await context.ParallelMatchPredictionBatches.AsNoTracking().CountAsync(b => b.RunId == runId);
+
+        private async Task<bool> IsCleanedUp(int runId) =>
+            await context.ParallelMatchPredictionRuns.AsNoTracking().Where(r => r.Id == runId).Select(r => r.IsCleanedUp).SingleAsync();
+    }
+}


### PR DESCRIPTION
CleanupOldParallelMatchPredictionBatches now finalises all runs older than retentionDays regardless of status.

Changes:
-Added IsCleanedUp (bit not null) to ParallelMatchPredictionRuns to track batch purging independently of Status. Cleanup deletes batch rows and sets the flag.

-Removed the FinalisedAndCleanedUp status from the enum. Migration backfills legacy rows to Status = 'Finalised', IsCleanedUp = 1.

-Finalisation queries now skip cleaned-up runs so they can't be reprocessed.

-Indexes updated to match the new query shape.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1474)
<!-- Reviewable:end -->
