### PR TITLE
feat: ATL-113: store parallel match prediction batch output as a sing…

### DIFF
--- a/Atlas.Functions/DurableFunctions/Search/Activity/SearchActivityFunctions.cs
+++ b/Atlas.Functions/DurableFunctions/Search/Activity/SearchActivityFunctions.cs
@@ -169,7 +169,7 @@ namespace Atlas.Functions.DurableFunctions.Search.Activity
 
             await matchPredictionSearchTrackingDispatcher.ProcessPrepareBatchesEnded(trackingSearchIdentifier, originalSearchIdentifier);
 
-            var parallelRunId = await parallelMatchPredictionRepository.CreateRun(
+            var runResult = await parallelMatchPredictionRepository.CreateRun(
                 new CreateParallelMatchPredictionRunInfo(
                     SearchIdentifier: new Guid(matchingResultsNotification.SearchRequestId),
                     IsRepeatSearch: matchingResultsNotification.IsRepeatSearch,
@@ -193,7 +193,8 @@ namespace Atlas.Functions.DurableFunctions.Search.Activity
                 RepeatSearchRequestId = matchingResultsNotification.IsRepeatSearch
                     ? matchingResultsNotification.RepeatSearchRequestId
                     : null,
-                ParallelRunId = parallelRunId,
+                ParallelRunId = runResult.RunId,
+                BatchId = runResult.BatchIdsBySequence[index],
                 BatchSequenceNumber = index,
             });
 

--- a/Atlas.Functions/DurableFunctions/Search/Activity/SearchActivityFunctions.cs
+++ b/Atlas.Functions/DurableFunctions/Search/Activity/SearchActivityFunctions.cs
@@ -169,7 +169,7 @@ namespace Atlas.Functions.DurableFunctions.Search.Activity
 
             await matchPredictionSearchTrackingDispatcher.ProcessPrepareBatchesEnded(trackingSearchIdentifier, originalSearchIdentifier);
 
-            var runResult = await parallelMatchPredictionRepository.CreateRun(
+            var runCreationResult = await parallelMatchPredictionRepository.CreateRun(
                 new CreateParallelMatchPredictionRunInfo(
                     SearchIdentifier: new Guid(matchingResultsNotification.SearchRequestId),
                     IsRepeatSearch: matchingResultsNotification.IsRepeatSearch,
@@ -193,8 +193,8 @@ namespace Atlas.Functions.DurableFunctions.Search.Activity
                 RepeatSearchRequestId = matchingResultsNotification.IsRepeatSearch
                     ? matchingResultsNotification.RepeatSearchRequestId
                     : null,
-                ParallelRunId = runResult.RunId,
-                BatchId = runResult.BatchIdsBySequence[index],
+                ParallelRunId = runCreationResult.RunId,
+                BatchId = runCreationResult.BatchIdsBySequence[index],
                 BatchSequenceNumber = index,
             });
 

--- a/Atlas.Functions/Functions/ParallelMatchPredictionAggregatorFunctions.cs
+++ b/Atlas.Functions/Functions/ParallelMatchPredictionAggregatorFunctions.cs
@@ -37,11 +37,9 @@ public class ParallelMatchPredictionAggregatorFunctions
     }
 
     /// <summary>
-    /// Session-aware Service Bus trigger. Persists a single batch result row keyed by
-    /// <c>(RunId, BatchSequenceNumber)</c>. Duplicate Service Bus deliveries are silently ignored at the
-    /// repository level (idempotency is enforced by the unique index, not by the function).
-    /// Failure results (<see cref="ParallelMatchPredictionBatchResult.IsSuccessful"/> == <c>false</c>) record
-    /// the batch as <c>Failed</c> so the run can still be finalised even when some batches fail.
+    /// Session-aware Service Bus trigger. Persists a single batch result row keyed by <c>BatchId</c>; duplicate
+    /// deliveries are ignored via the batch status. Failure results are recorded as <c>Failed</c> so the run can
+    /// still be finalised.
     /// </summary>
     [Function(nameof(StoreParallelMatchPredictionBatchResult))]
     public async Task StoreParallelMatchPredictionBatchResult(
@@ -57,31 +55,29 @@ public class ParallelMatchPredictionAggregatorFunctions
         if (message.IsSuccessful)
         {
             var wasBatchResultRecordedSuccessfully = await repository.RecordBatchResult(
-                message.ParallelRunId,
-                message.BatchSequenceNumber,
-                message.MatchPredictionResultLocations
+                message.BatchId,
+                message.MatchPredictionResultLocation
             );
 
             if (wasBatchResultRecordedSuccessfully)
             {
                 logger.LogInformation(
-                    "Recorded parallel MPA batch result. RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}.",
-                    message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier
+                    "Recorded parallel MPA batch result. BatchId={BatchId}, RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}.",
+                    message.BatchId, message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier
                 );
             }
             else
             {
                 logger.LogWarning(
-                    "Duplicate parallel MPA batch result ignored. RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}.",
-                    message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier
+                    "Duplicate parallel MPA batch result ignored. BatchId={BatchId}, RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}.",
+                    message.BatchId, message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier
                 );
             }
         }
         else
         {
             var wasFailureRecordedSuccessfully = await repository.RecordBatchFailure(
-                message.ParallelRunId,
-                message.BatchSequenceNumber,
+                message.BatchId,
                 message.FailureMessage,
                 message.FailureException
             );
@@ -89,15 +85,15 @@ public class ParallelMatchPredictionAggregatorFunctions
             if (wasFailureRecordedSuccessfully)
             {
                 logger.LogError(
-                    "Recorded parallel MPA batch failure. RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}. Failure: {FailureMessage}",
-                    message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier, message.FailureMessage
+                    "Recorded parallel MPA batch failure. BatchId={BatchId}, RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}. Failure: {FailureMessage}",
+                    message.BatchId, message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier, message.FailureMessage
                 );
             }
             else
             {
                 logger.LogWarning(
-                    "Duplicate parallel MPA batch failure ignored. RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}.",
-                    message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier
+                    "Duplicate parallel MPA batch failure ignored. BatchId={BatchId}, RunId={RunId}, BatchSequenceNumber={BatchSequenceNumber}, Search={SearchIdentifier}.",
+                    message.BatchId, message.ParallelRunId, message.BatchSequenceNumber, message.SearchIdentifier
                 );
             }
         }

--- a/Atlas.Functions/Services/ParallelMatchPredictionCompletionService.cs
+++ b/Atlas.Functions/Services/ParallelMatchPredictionCompletionService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Atlas.Client.Models.Search.Results;
 using Atlas.Client.Models.Search.Results.LogFile;
 using Atlas.Client.Models.Search.Results.Matching;
+using Atlas.Client.Models.Search.Results.MatchPrediction;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.ApplicationInsights.Timing;
 using Atlas.Common.AzureStorage.Blob;
@@ -91,7 +92,6 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
         }
 
         var run = runResults.Run;
-        var resultsLocations = runResults.MergedResultLocations;
 
         try
         {
@@ -108,7 +108,7 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
                 return;
             }
 
-            await CompleteSuccessfulRun(runId, run, resultsLocations, trackingSearchIdentifier, originalSearchIdentifier);
+            await CompleteSuccessfulRun(runId, run, runResults.BatchResultLocations, trackingSearchIdentifier, originalSearchIdentifier);
         }
         catch
         {
@@ -202,7 +202,7 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
     private async Task CompleteSuccessfulRun(
         int runId,
         Atlas.MatchPrediction.Data.Models.ParallelMatchPredictionRun run,
-        IReadOnlyDictionary<int, string> resultsLocations,
+        IReadOnlyList<string> batchResultLocations,
         Guid trackingSearchIdentifier,
         Guid? originalSearchIdentifier)
     {
@@ -228,17 +228,23 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
             : azureStorageSettings.SearchResultsBlobContainer;
         resultSet.BatchedResult = run.ResultsBatched && azureStorageSettings.ShouldBatchResults;
 
+        // Download the per-batch result blobs and merge into one donor → result map.
+        var matchPredictionResults = await logger.RunTimedAsync(
+            "Download match prediction batch results",
+            async () => await resultsCombiner.DownloadBatchedMatchPredictionResults(batchResultLocations)
+        );
+
         resultSet.Results = await logger.RunTimedAsync("Combining search results", async () =>
             run.ResultsBatched
                 ? await CombineBatchedSearchResults(
                     resultSet.SearchRequestId,
                     run.IsRepeatSearch,
-                    resultsLocations,
+                    matchPredictionResults,
                     run.BatchFolderName,
                     resultSet.BlobStorageContainerName,
                     azureStorageSettings.ShouldBatchResults
                 )
-                : await resultsCombiner.CombineResults(resultSet.SearchRequestId, matchingResultsSummary.Results, resultsLocations)
+                : resultsCombiner.CombineResults(resultSet.SearchRequestId, matchingResultsSummary.Results, matchPredictionResults)
         );
 
         await searchResultsBlobUploader.UploadResults(
@@ -301,7 +307,7 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
     private async Task<IEnumerable<SearchResult>> CombineBatchedSearchResults(
         string searchRequestId,
         bool isRepeatSearch,
-        IReadOnlyDictionary<int, string> matchPredictionResultLocations,
+        IReadOnlyDictionary<int, MatchProbabilityResponse> matchPredictionResults,
         string batchFolder,
         string blobStorageContainerName,
         bool resultsShouldBeBatched)
@@ -312,11 +318,11 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
         await foreach (var matchingResults in matchingResultsDownloader.DownloadResults(isRepeatSearch, batchFolder))
         {
             var matchingAlgorithmResults = matchingResults.ToList();
-            var donorIds = matchingAlgorithmResults.Select(r => r.AtlasDonorId).ToList();
-            var matchPredictionResultLocationsForCurrentDonors =
-                matchPredictionResultLocations.Where(l => donorIds.Contains(l.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+            var donorIds = matchingAlgorithmResults.Select(r => r.AtlasDonorId).ToHashSet();
+            var matchPredictionResultsForCurrentDonors =
+                matchPredictionResults.Where(r => donorIds.Contains(r.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
             var currentSearchResults =
-                await resultsCombiner.CombineResults(searchRequestId, matchingAlgorithmResults, matchPredictionResultLocationsForCurrentDonors);
+                resultsCombiner.CombineResults(searchRequestId, matchingAlgorithmResults, matchPredictionResultsForCurrentDonors);
 
             if (resultsShouldBeBatched)
             {

--- a/Atlas.Functions/Services/ResultsCombiner.cs
+++ b/Atlas.Functions/Services/ResultsCombiner.cs
@@ -23,6 +23,22 @@ namespace Atlas.Functions.Services
             IEnumerable<MatchingAlgorithmResult> matchingAlgorithmResults,
             IReadOnlyDictionary<int, string> matchPredictionResultLocations);
 
+        /// <summary>
+        /// Combines matching results with already-downloaded match prediction results (keyed by Atlas donor id).
+        /// Used by the parallel path.
+        /// </summary>
+        IEnumerable<SearchResult> CombineResults(
+            string searchRequestId,
+            IEnumerable<MatchingAlgorithmResult> matchingAlgorithmResults,
+            IReadOnlyDictionary<int, MatchProbabilityResponse> matchPredictionResults);
+
+        /// <summary>
+        /// Downloads every per-batch result blob (each a <c>Dictionary&lt;int, MatchProbabilityResponse&gt;</c>) and
+        /// merges them into a single donor → result map.
+        /// </summary>
+        Task<IReadOnlyDictionary<int, MatchProbabilityResponse>> DownloadBatchedMatchPredictionResults(
+            IReadOnlyCollection<string> batchResultLocations);
+
         SearchResultSet BuildResultsSummary(ResultSet<MatchingAlgorithmResult> matchingAlgorithmResultSet, TimeSpan matchPredictionTime, TimeSpan matchingTime);
     }
 
@@ -89,6 +105,52 @@ namespace Atlas.Functions.Services
                     MatchingResult = r,
                     MatchPredictionResult = matchCategoryService.ReOrientatePositionalMatchCategories(matchPredictionResults[r.AtlasDonorId], r.ScoringResult)
                 });
+            }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<SearchResult> CombineResults(
+            string searchRequestId,
+            IEnumerable<MatchingAlgorithmResult> matchingAlgorithmResults,
+            IReadOnlyDictionary<int, MatchProbabilityResponse> matchPredictionResults)
+        {
+            using (logger.RunTimed($"Combine search results: {searchRequestId}"))
+            {
+                return matchingAlgorithmResults.Select(r => new SearchResult
+                {
+                    DonorCode = r.MatchingDonorInfo.ExternalDonorCode,
+                    MatchingResult = r,
+                    MatchPredictionResult = matchCategoryService.ReOrientatePositionalMatchCategories(matchPredictionResults[r.AtlasDonorId], r.ScoringResult)
+                }).ToList();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyDictionary<int, MatchProbabilityResponse>> DownloadBatchedMatchPredictionResults(
+            IReadOnlyCollection<string> batchResultLocations)
+        {
+            using (logger.RunTimed("Download match prediction algorithm results"))
+            {
+                logger.SendTrace($"{batchResultLocations.Count} batch result file(s) to download");
+
+                var merged = new Dictionary<int, MatchProbabilityResponse>();
+                foreach (var locationBatch in batchResultLocations.Chunk(matchPredictionDownloadBatchSize))
+                {
+                    var downloadTasks = locationBatch
+                        .Select(location => blobDownloader.Download<Dictionary<int, MatchProbabilityResponse>>(matchPredictionResultsContainer, location))
+                        .ToList();
+                    var downloadedBatches = await Task.WhenAll(downloadTasks);
+
+                    foreach (var batchResults in downloadedBatches)
+                    {
+                        foreach (var donorResult in batchResults)
+                        {
+                            merged[donorResult.Key] = donorResult.Value;
+                        }
+                    }
+                }
+
+                return merged;
             }
         }
 

--- a/Atlas.Functions/Services/ResultsCombiner.cs
+++ b/Atlas.Functions/Services/ResultsCombiner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -133,22 +134,21 @@ namespace Atlas.Functions.Services
             {
                 logger.SendTrace($"{batchResultLocations.Count} batch result file(s) to download");
 
-                var merged = new Dictionary<int, MatchProbabilityResponse>();
-                foreach (var locationBatch in batchResultLocations.Chunk(matchPredictionDownloadBatchSize))
-                {
-                    var downloadTasks = locationBatch
-                        .Select(location => blobDownloader.Download<Dictionary<int, MatchProbabilityResponse>>(matchPredictionResultsContainer, location))
-                        .ToList();
-                    var downloadedBatches = await Task.WhenAll(downloadTasks);
+                // Download concurrently, throttled to matchPredictionDownloadBatchSize in-flight downloads.
+                // Donor ids are partitioned across batches, so batches never share a key and the merge order is irrelevant.
+                var merged = new ConcurrentDictionary<int, MatchProbabilityResponse>();
 
-                    foreach (var batchResults in downloadedBatches)
+                await Parallel.ForEachAsync(
+                    batchResultLocations,
+                    new ParallelOptions { MaxDegreeOfParallelism = matchPredictionDownloadBatchSize },
+                    async (location, _) =>
                     {
+                        var batchResults = await blobDownloader.Download<Dictionary<int, MatchProbabilityResponse>>(matchPredictionResultsContainer, location);
                         foreach (var donorResult in batchResults)
                         {
                             merged[donorResult.Key] = donorResult.Value;
                         }
-                    }
-                }
+                    });
 
                 return merged;
             }

--- a/Atlas.MatchPrediction.Data/Migrations/20260706130641_ReplaceParallelBatchResultLocationJsonWithResultLocation.Designer.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260706130641_ReplaceParallelBatchResultLocationJsonWithResultLocation.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.MatchPrediction.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.MatchPrediction.Data.Migrations
 {
     [DbContext(typeof(MatchPredictionContext))]
-    partial class MatchPredictionContextModelSnapshot : ModelSnapshot
+    [Migration("20260706130641_ReplaceParallelBatchResultLocationJsonWithResultLocation")]
+    partial class ReplaceParallelBatchResultLocationJsonWithResultLocation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -184,9 +187,6 @@ namespace Atlas.MatchPrediction.Data.Migrations
                     b.Property<DateTime?>("FinalisedTimeUtc")
                         .HasColumnType("datetime2");
 
-                    b.Property<bool>("IsCleanedUp")
-                        .HasColumnType("bit");
-
                     b.Property<bool>("IsRepeatSearch")
                         .HasColumnType("bit");
 
@@ -229,11 +229,7 @@ namespace Atlas.MatchPrediction.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Status")
-                        .HasDatabaseName("IX_ParallelMatchPredictionRuns_Status_Running")
-                        .HasFilter("[Status] = 'Running'");
-
-                    b.HasIndex("IsCleanedUp", "MatchPredictionRunInitiatedUtc");
+                    b.HasIndex("Status", "FinalisedTimeUtc");
 
                     b.ToTable("ParallelMatchPredictionRuns", "MatchPrediction");
                 });

--- a/Atlas.MatchPrediction.Data/Migrations/20260706130641_ReplaceParallelBatchResultLocationJsonWithResultLocation.cs
+++ b/Atlas.MatchPrediction.Data/Migrations/20260706130641_ReplaceParallelBatchResultLocationJsonWithResultLocation.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.MatchPrediction.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReplaceParallelBatchResultLocationJsonWithResultLocation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ResultLocationJson",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionBatches");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ResultLocation",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionBatches",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ResultLocation",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionBatches");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ResultLocationJson",
+                schema: "MatchPrediction",
+                table: "ParallelMatchPredictionBatches",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionBatch.cs
+++ b/Atlas.MatchPrediction.Data/Models/ParallelMatchPredictionBatch.cs
@@ -7,10 +7,9 @@ namespace Atlas.MatchPrediction.Data.Models;
 
 /// <summary>
 /// One row per batch in a parallel match-prediction run, pre-created before any batch messages are dispatched.
-/// Idempotency for result recording is enforced by the <see cref="BatchStatus"/> field — once a result
-/// is received (or a failure recorded), the row is updated atomically; duplicate Service Bus deliveries are detected and ignored.
-/// The unique <c>(RunId, BatchSequenceNumber)</c> index is used to find the correct row to update.
-/// Rows are purged by the clean-up timer after the parent run is finalised (the parent row itself is kept).
+/// The row's <see cref="Id"/> is stamped onto the dispatched request and echoed back on the result, so the aggregator
+/// locates and updates the row by primary key; idempotency is enforced by <see cref="BatchStatus"/> (duplicate
+/// deliveries are ignored). Rows are purged by the clean-up timer after the parent run is finalised.
 /// </summary>
 [Index(nameof(RunId), nameof(BatchSequenceNumber), IsUnique = true)]
 public class ParallelMatchPredictionBatch
@@ -23,12 +22,7 @@ public class ParallelMatchPredictionBatch
 
     public ParallelMatchPredictionRun Run { get; set; }
 
-    /// <summary>
-    /// Zero-based sequence number assigned by the orchestrator when the batch is dispatched.
-    /// Together with <see cref="RunId"/> forms the idempotency key used to locate this row when a result arrives.
-    /// The same sequence number is embedded in the <c>ParallelMatchPredictionBatchRequest</c> message and
-    /// echoed back on the <c>ParallelMatchPredictionBatchResult</c> message so the aggregator can find this row.
-    /// </summary>
+    /// <summary>Zero-based sequence number assigned by the orchestrator. Retained for logging and ordering.</summary>
     public int BatchSequenceNumber { get; set; }
 
     /// <summary>
@@ -44,12 +38,11 @@ public class ParallelMatchPredictionBatch
     public DateTime? ResultReceivedTimeUtc { get; set; }
 
     /// <summary>
-    /// JSON-serialised <c>IReadOnlyDictionary&lt;int, string&gt;</c> mapping Atlas donor id to
-    /// the blob filename (relative to the match-prediction-results container) holding that
-    /// donor's per-batch MPA result. <c>null</c> until a successful result arrives.
+    /// Blob filename of the single file holding this batch's donor → MPA result map. <c>null</c> until a successful
+    /// result arrives (or when the batch had no donors).
     /// </summary>
-    [MaxLength]
-    public string ResultLocationJson { get; set; }
+    [MaxLength(1024)]
+    public string ResultLocation { get; set; }
 
     /// <summary>
     /// Human-readable failure message from the Worker exception.

--- a/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
+++ b/Atlas.MatchPrediction.Data/Repositories/ParallelMatchPredictionRepository.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
-using Atlas.Common.Utils.Extensions;
 using Atlas.MatchPrediction.Data.Context;
 using Atlas.MatchPrediction.Data.Models;
 using Microsoft.EntityFrameworkCore;
@@ -22,13 +20,18 @@ public record CreateParallelMatchPredictionRunInfo(
     int TotalBatchCount);
 
 /// <summary>
-/// A run together with the merged donor → blob location map built from all of its received batch rows.
+/// The new run id together with the ids of its pre-created batch rows, indexed by batch sequence number
+/// (<c>BatchIdsBySequence[seq]</c> is the id of the batch with <c>BatchSequenceNumber == seq</c>).
 /// </summary>
+public record CreateParallelMatchPredictionRunResult(int RunId, IReadOnlyList<int> BatchIdsBySequence);
+
+/// <summary>A run together with the result-file locations of its received batches, plus any failed batches.</summary>
 public class ParallelMatchPredictionRunResults
 {
     public ParallelMatchPredictionRun Run { get; init; }
 
-    public IReadOnlyDictionary<int, string> MergedResultLocations { get; init; }
+    /// <summary>Blob filenames of the result files for every batch with a non-null location.</summary>
+    public IReadOnlyList<string> BatchResultLocations { get; init; }
 
     /// <summary>Batches whose <see cref="ParallelMatchPredictionBatch.BatchStatus"/> is <see cref="ParallelMatchPredictionBatchStatus.Failed"/>.</summary>
     public IReadOnlyList<ParallelMatchPredictionBatch> FailedBatches { get; init; }
@@ -37,38 +40,26 @@ public class ParallelMatchPredictionRunResults
 public interface IParallelMatchPredictionRepository
 {
     /// <summary>
-    /// Creates the parent run record (with status <see cref="ParallelMatchPredictionRunStatus.Running"/>) and
-    /// pre-creates one <see cref="ParallelMatchPredictionBatch"/> row per expected batch
-    /// (<c>BatchSequenceNumber</c> 0 … <c>TotalBatchCount − 1</c>) before any batch messages are dispatched.
-    /// Returns the new run id.
+    /// Creates the parent run record and pre-creates one <see cref="ParallelMatchPredictionBatch"/> row per expected
+    /// batch (<c>BatchSequenceNumber</c> 0 … <c>TotalBatchCount − 1</c>) before any batch messages are dispatched.
     /// </summary>
-    Task<int> CreateRun(CreateParallelMatchPredictionRunInfo info);
+    Task<CreateParallelMatchPredictionRunResult> CreateRun(CreateParallelMatchPredictionRunInfo info);
 
     /// <summary>
-    /// Records a single successful batch result by updating the pre-created batch row keyed by
-    /// <c>(runId, batchSequenceNumber)</c>. Idempotent: if the result was already recorded the update
-    /// is a no-op and <c>false</c> is returned.
+    /// Records a successful batch result by updating the pre-created batch row identified by <paramref name="batchId"/>.
+    /// Idempotent — a duplicate delivery is a no-op returning <c>false</c>.
     /// </summary>
-    /// <returns>
-    /// <c>true</c> if this is the first time the result was recorded; <c>false</c> if it was a duplicate.
-    /// </returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when no pre-created batch row exists for the given key, which indicates an invalid message or data corruption.
-    /// </exception>
-    Task<bool> RecordBatchResult(int runId, int batchSequenceNumber, IReadOnlyDictionary<int, string> resultLocations);
+    /// <returns><c>true</c> on first record; <c>false</c> if it was a duplicate.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no batch row exists for the given id.</exception>
+    Task<bool> RecordBatchResult(int batchId, string resultLocation);
 
     /// <summary>
-    /// Records a batch failure by updating the pre-created batch row keyed by
-    /// <c>(runId, batchSequenceNumber)</c>. Idempotent: if the batch was already recorded the update
-    /// is a no-op and <c>false</c> is returned.
+    /// Records a batch failure by updating the pre-created batch row identified by <paramref name="batchId"/>.
+    /// Idempotent — a duplicate delivery is a no-op returning <c>false</c>.
     /// </summary>
-    /// <returns>
-    /// <c>true</c> if this is the first time the failure was recorded; <c>false</c> if it was a duplicate.
-    /// </returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when no pre-created batch row exists for the given key.
-    /// </exception>
-    Task<bool> RecordBatchFailure(int runId, int batchSequenceNumber, string failureMessage, string failureException);
+    /// <returns><c>true</c> on first record; <c>false</c> if it was a duplicate.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no batch row exists for the given id.</exception>
+    Task<bool> RecordBatchFailure(int batchId, string failureMessage, string failureException);
 
     /// <summary>
     /// Returns the ids of all <see cref="ParallelMatchPredictionRunStatus.Running"/> runs whose every batch
@@ -93,7 +84,7 @@ public interface IParallelMatchPredictionRepository
     Task<bool> TryClaimFinalisationLease(int runId, Guid leaseOwner);
 
     /// <summary>
-    /// Returns the run together with the merged donor → blob location map built from its received batch rows.
+    /// Returns the run together with the blob locations of each successfully-received batch's result file.
     /// Returns <c>null</c> if the run does not exist.
     /// </summary>
     Task<ParallelMatchPredictionRunResults> GetRunWithResults(int runId);
@@ -143,7 +134,7 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
         this.context = context;
     }
 
-    public async Task<int> CreateRun(CreateParallelMatchPredictionRunInfo info)
+    public async Task<CreateParallelMatchPredictionRunResult> CreateRun(CreateParallelMatchPredictionRunInfo info)
     {
         await using var transaction = await context.Database.BeginTransactionAsync();
         try
@@ -168,7 +159,8 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             };
             context.ParallelMatchPredictionRuns.Add(entity);
 
-            // Pre-create one batch row per expected batch so that results can be recorded via UPDATE rather than INSERT.
+            // Pre-create one batch row per expected batch (in sequence order) so results can be recorded via UPDATE.
+            var batches = new List<ParallelMatchPredictionBatch>(info.TotalBatchCount);
             for (var seq = 0; seq < info.TotalBatchCount; seq++)
             {
                 var matchPredictionBatch = new ParallelMatchPredictionBatch
@@ -177,13 +169,17 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
                     BatchSequenceNumber = seq,
                     BatchStatus = ParallelMatchPredictionBatchStatus.Requested,
                 };
+                batches.Add(matchPredictionBatch);
                 context.ParallelMatchPredictionBatches.Add(matchPredictionBatch);
             }
 
             await context.SaveChangesAsync();
 
             await transaction.CommitAsync();
-            return entity.Id;
+
+            // Ids are populated by SaveChanges; batches is in ascending sequence order.
+            var batchIdsBySequence = batches.Select(b => b.Id).ToList();
+            return new CreateParallelMatchPredictionRunResult(entity.Id, batchIdsBySequence);
         }
         catch
         {
@@ -192,21 +188,19 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
         }
     }
 
-    public async Task<bool> RecordBatchResult(int runId, int batchSequenceNumber, IReadOnlyDictionary<int, string> resultLocations)
+    public async Task<bool> RecordBatchResult(int batchId, string resultLocation)
     {
         var now = DateTime.UtcNow;
-        var serializedLocations = JsonSerializer.Serialize(resultLocations);
 
         // Atomically update only if still Requested — prevents overwriting with a duplicate delivery.
         var rowsUpdated = await context.ParallelMatchPredictionBatches
-            .Where(b => b.RunId == runId
-                     && b.BatchSequenceNumber == batchSequenceNumber
+            .Where(b => b.Id == batchId
                      && b.BatchStatus == ParallelMatchPredictionBatchStatus.Requested
             )
             .ExecuteUpdateAsync(s => s
                 .SetProperty(b => b.BatchStatus, ParallelMatchPredictionBatchStatus.ResultsReceived)
                 .SetProperty(b => b.ResultReceivedTimeUtc, now)
-                .SetProperty(b => b.ResultLocationJson, serializedLocations)
+                .SetProperty(b => b.ResultLocation, resultLocation)
             );
 
         if (rowsUpdated == 1)
@@ -216,13 +210,13 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
 
         // Distinguish "already received" (idempotent duplicate) from "row not found" (data error).
         var exists = await context.ParallelMatchPredictionBatches
-            .AnyAsync(b => b.RunId == runId && b.BatchSequenceNumber == batchSequenceNumber);
+            .AnyAsync(b => b.Id == batchId);
 
         if (!exists)
         {
             throw new InvalidOperationException(
-                $"No pre-created batch row found for RunId={runId}, BatchSequenceNumber={batchSequenceNumber}. "
-              + "This indicates an invalid message or data corruption — a batch result was received for a run/batch that was never registered."
+                $"No pre-created batch row found for BatchId={batchId}. "
+              + "This indicates an invalid message or data corruption — a batch result was received for a batch that was never registered."
             );
         }
 
@@ -230,14 +224,13 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
         return false;
     }
 
-    public async Task<bool> RecordBatchFailure(int runId, int batchSequenceNumber, string failureMessage, string failureException)
+    public async Task<bool> RecordBatchFailure(int batchId, string failureMessage, string failureException)
     {
         var now = DateTime.UtcNow;
 
         // Atomically update only if still Requested — prevents overwriting with a duplicate delivery.
         var rowsUpdated = await context.ParallelMatchPredictionBatches
-            .Where(b => b.RunId == runId
-                     && b.BatchSequenceNumber == batchSequenceNumber
+            .Where(b => b.Id == batchId
                      && b.BatchStatus == ParallelMatchPredictionBatchStatus.Requested
             )
             .ExecuteUpdateAsync(s => s
@@ -253,13 +246,13 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
         }
 
         var exists = await context.ParallelMatchPredictionBatches
-            .AnyAsync(b => b.RunId == runId && b.BatchSequenceNumber == batchSequenceNumber);
+            .AnyAsync(b => b.Id == batchId);
 
         if (!exists)
         {
             throw new InvalidOperationException(
-                $"No pre-created batch row found for RunId={runId}, BatchSequenceNumber={batchSequenceNumber}. "
-              + "This indicates an invalid message or data corruption — a batch failure was received for a run/batch that was never registered."
+                $"No pre-created batch row found for BatchId={batchId}. "
+              + "This indicates an invalid message or data corruption — a batch failure was received for a batch that was never registered."
             );
         }
 
@@ -310,13 +303,10 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
             return null;
         }
 
-        var mergedResultLocations = new Dictionary<int, string>();
-        foreach (var batch in run.Batches.Where(b => b.BatchStatus == ParallelMatchPredictionBatchStatus.ResultsReceived))
-        {
-            var currentBatchResultLocations = JsonSerializer.Deserialize<Dictionary<int, string>>(batch.ResultLocationJson)
-                                           ?? new Dictionary<int, string>();
-            mergedResultLocations = mergedResultLocations.Merge(currentBatchResultLocations);
-        }
+        var batchResultLocations = run.Batches
+            .Where(b => b.BatchStatus == ParallelMatchPredictionBatchStatus.ResultsReceived && b.ResultLocation != null)
+            .Select(b => b.ResultLocation)
+            .ToList();
 
         var failedBatches = run.Batches
             .Where(b => b.BatchStatus == ParallelMatchPredictionBatchStatus.Failed)
@@ -325,7 +315,7 @@ public class ParallelMatchPredictionRepository : IParallelMatchPredictionReposit
         return new ParallelMatchPredictionRunResults
         {
             Run = run,
-            MergedResultLocations = mergedResultLocations,
+            BatchResultLocations = batchResultLocations,
             FailedBatches = failedBatches,
         };
     }

--- a/Atlas.MatchPrediction.Test/Services/ParallelMatchPredictionAlgorithmTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/ParallelMatchPredictionAlgorithmTests.cs
@@ -26,7 +26,7 @@ namespace Atlas.MatchPrediction.Test.Services
     {
         private IMatchProbabilityService matchProbabilityService;
         private IGenotypeSetService genotypeSetService;
-        private ISearchDonorResultUploader resultUploader;
+        private IMatchPredictionBatchResultUploader resultUploader;
         private IMatchPredictionLogger<MatchProbabilityLoggingContext> logger;
         private IServiceScopeFactory serviceScopeFactory;
         private IParallelMatchPredictionAlgorithm sut;
@@ -36,7 +36,7 @@ namespace Atlas.MatchPrediction.Test.Services
         {
             matchProbabilityService = Substitute.For<IMatchProbabilityService>();
             genotypeSetService = Substitute.For<IGenotypeSetService>();
-            resultUploader = Substitute.For<ISearchDonorResultUploader>();
+            resultUploader = Substitute.For<IMatchPredictionBatchResultUploader>();
             logger = Substitute.For<IMatchPredictionLogger<MatchProbabilityLoggingContext>>();
             serviceScopeFactory = Substitute.For<IServiceScopeFactory>();
 
@@ -46,7 +46,7 @@ namespace Atlas.MatchPrediction.Test.Services
             genotypeSetService.GetPatientGenotypeSet(default).ReturnsForAnyArgs(patientGenotypeSet);
 
             matchProbabilityService.CalculateMatchProbability(default, default).ReturnsForAnyArgs(new MatchProbabilityResponse(null, new HashSet<Locus>()));
-            resultUploader.UploadBatchResult(default, default, default).ReturnsForAnyArgs("batch-result.json");
+            resultUploader.UploadMatchPredictionBatchResult(default, default, default).ReturnsForAnyArgs("batch-result.json");
 
             serviceScopeFactory.CreateScope().Returns(_ => CreateMockScope());
         }
@@ -153,7 +153,7 @@ namespace Atlas.MatchPrediction.Test.Services
             var resultLocation = await sut.RunBatch(input, maxDegreeOfParallelism: 10, batchId: 42);
 
             Assert.That(resultLocation, Is.EqualTo("batch-result.json"));
-            await resultUploader.Received(1).UploadBatchResult(
+            await resultUploader.Received(1).UploadMatchPredictionBatchResult(
                 "search-request-id",
                 42,
                 Arg.Is<IReadOnlyDictionary<int, MatchProbabilityResponse>>(d =>
@@ -175,7 +175,7 @@ namespace Atlas.MatchPrediction.Test.Services
             var resultLocation = await sut.RunBatch(input, maxDegreeOfParallelism: 10, batchId: 42);
 
             Assert.That(resultLocation, Is.Null);
-            await resultUploader.DidNotReceiveWithAnyArgs().UploadBatchResult(default, default, default);
+            await resultUploader.DidNotReceiveWithAnyArgs().UploadMatchPredictionBatchResult(default, default, default);
         }
     }
 }

--- a/Atlas.MatchPrediction.Test/Services/ParallelMatchPredictionAlgorithmTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/ParallelMatchPredictionAlgorithmTests.cs
@@ -40,14 +40,13 @@ namespace Atlas.MatchPrediction.Test.Services
             logger = Substitute.For<IMatchPredictionLogger<MatchProbabilityLoggingContext>>();
             serviceScopeFactory = Substitute.For<IServiceScopeFactory>();
 
-            sut = new ParallelMatchPredictionAlgorithm(genotypeSetService, logger, serviceScopeFactory);
+            sut = new ParallelMatchPredictionAlgorithm(genotypeSetService, resultUploader, logger, serviceScopeFactory);
 
             var patientGenotypeSet = new SubjectGenotypeSet(false, new List<GenotypeAtDesiredResolutions>(), 0.1m);
             genotypeSetService.GetPatientGenotypeSet(default).ReturnsForAnyArgs(patientGenotypeSet);
 
             matchProbabilityService.CalculateMatchProbability(default, default).ReturnsForAnyArgs(new MatchProbabilityResponse(null, new HashSet<Locus>()));
-            resultUploader.UploadSearchDonorResults(default, default, default).ReturnsForAnyArgs(call =>
-                ((IEnumerable<int>)call[1]).ToDictionary(id => id, id => $"{id}.json"));
+            resultUploader.UploadBatchResult(default, default, default).ReturnsForAnyArgs("batch-result.json");
 
             serviceScopeFactory.CreateScope().Returns(_ => CreateMockScope());
         }
@@ -56,7 +55,6 @@ namespace Atlas.MatchPrediction.Test.Services
         {
             var serviceProvider = Substitute.For<IServiceProvider>();
             serviceProvider.GetService(typeof(IMatchProbabilityService)).Returns(matchProbabilityService);
-            serviceProvider.GetService(typeof(ISearchDonorResultUploader)).Returns(resultUploader);
             serviceProvider.GetService(typeof(IMatchPredictionLogger<MatchProbabilityLoggingContext>)).Returns(logger);
             var scope = Substitute.For<IServiceScope>();
             scope.ServiceProvider.Returns(serviceProvider);
@@ -82,7 +80,7 @@ namespace Atlas.MatchPrediction.Test.Services
                 }
             };
 
-            await sut.RunBatch(input, maxDegreeOfParallelism: 10);
+            await sut.RunBatch(input, maxDegreeOfParallelism: 10, batchId: 1);
 
             await genotypeSetService.Received(1).GetPatientGenotypeSet(Arg.Any<SingleDonorMatchProbabilityInput>());
             await matchProbabilityService.Received(2).CalculateMatchProbability(
@@ -107,7 +105,7 @@ namespace Atlas.MatchPrediction.Test.Services
                 }
             };
 
-            await sut.RunBatch(input, maxDegreeOfParallelism: 1);
+            await sut.RunBatch(input, maxDegreeOfParallelism: 1, batchId: 1);
 
             await matchProbabilityService.Received(3).CalculateMatchProbability(
                 Arg.Any<SingleDonorMatchProbabilityInput>(),
@@ -131,13 +129,13 @@ namespace Atlas.MatchPrediction.Test.Services
                 }
             };
 
-            await sut.RunBatch(input, maxDegreeOfParallelism: 10);
+            await sut.RunBatch(input, maxDegreeOfParallelism: 10, batchId: 1);
 
             serviceScopeFactory.Received(3).CreateScope();
         }
 
         [Test]
-        public async Task RunBatch_AggregatesAllDonorResults()
+        public async Task RunBatch_UploadsAllDonorResultsInSingleFileAndReturnsItsLocation()
         {
             var input = new MultipleDonorMatchProbabilityInput(new IdentifiedMatchProbabilityRequest
             {
@@ -152,11 +150,32 @@ namespace Atlas.MatchPrediction.Test.Services
                 }
             };
 
-            var results = await sut.RunBatch(input, maxDegreeOfParallelism: 10);
+            var resultLocation = await sut.RunBatch(input, maxDegreeOfParallelism: 10, batchId: 42);
 
-            Assert.That(results.Keys, Is.EquivalentTo(new[] { 1, 2 }));
-            Assert.That(results[1], Is.EqualTo("1.json"));
-            Assert.That(results[2], Is.EqualTo("2.json"));
+            Assert.That(resultLocation, Is.EqualTo("batch-result.json"));
+            await resultUploader.Received(1).UploadBatchResult(
+                "search-request-id",
+                42,
+                Arg.Is<IReadOnlyDictionary<int, MatchProbabilityResponse>>(d =>
+                    d.Count == 2 && d.ContainsKey(1) && d.ContainsKey(2)));
+        }
+
+        [Test]
+        public async Task RunBatch_WithNoDonors_ReturnsNullAndDoesNotUpload()
+        {
+            var input = new MultipleDonorMatchProbabilityInput(new IdentifiedMatchProbabilityRequest
+            {
+                SearchRequestId = "search-request-id",
+                PatientHla = new PhenotypeInfo<string>("patient-hla").ToPhenotypeInfoTransfer()
+            })
+            {
+                Donors = new List<DonorInput>()
+            };
+
+            var resultLocation = await sut.RunBatch(input, maxDegreeOfParallelism: 10, batchId: 42);
+
+            Assert.That(resultLocation, Is.Null);
+            await resultUploader.DidNotReceiveWithAnyArgs().UploadBatchResult(default, default, default);
         }
     }
 }

--- a/Atlas.MatchPrediction.Worker/Services/ParallelMatchPredictionBatchRunner.cs
+++ b/Atlas.MatchPrediction.Worker/Services/ParallelMatchPredictionBatchRunner.cs
@@ -61,6 +61,7 @@ internal class ParallelMatchPredictionBatchRunner : IParallelMatchPredictionBatc
                 SearchIdentifier = new Guid(request.SearchRequestId),
                 RepeatSearchIdentifier = request.RepeatSearchRequestId == null ? null : new Guid(request.RepeatSearchRequestId),
                 ParallelRunId = request.ParallelRunId,
+                BatchId = request.BatchId,
                 BatchSequenceNumber = request.BatchSequenceNumber,
                 IsSuccessful = false,
                 FailureMessage = ex.Message,
@@ -101,13 +102,13 @@ internal class ParallelMatchPredictionBatchRunner : IParallelMatchPredictionBatc
 
         await trackingDispatcher.ProcessRunningBatchesStarted(searchIdentifier, originalSearchIdentifier);
 
-        var results = await parallelMatchPredictionAlgorithm.RunBatch(batchInput, maxDegreeOfParallelism);
+        var resultLocation = await parallelMatchPredictionAlgorithm.RunBatch(batchInput, maxDegreeOfParallelism, request.BatchId);
 
         await trackingDispatcher.ProcessRunningBatchesEnded(searchIdentifier, originalSearchIdentifier);
 
         logger.LogInformation(
-            "Completed match prediction for {DonorCount} donors for search {SearchRequestId}, blob {BlobLocation}",
-            results.Count, request.SearchRequestId, request.BlobLocation
+            "Completed match prediction for batch {BatchId} ({DonorCount} donors) for search {SearchRequestId}; stored results in single blob {ResultLocation}",
+            request.BatchId, batchInput.Donors?.Count, request.SearchRequestId, resultLocation
         );
 
         var batchResult = new ParallelMatchPredictionBatchResult
@@ -115,16 +116,17 @@ internal class ParallelMatchPredictionBatchRunner : IParallelMatchPredictionBatc
             SearchIdentifier = new Guid(request.SearchRequestId),
             RepeatSearchIdentifier = request.RepeatSearchRequestId == null ? null : new Guid(request.RepeatSearchRequestId),
             IsSuccessful = true,
-            MatchPredictionResultLocations = results,
+            MatchPredictionResultLocation = resultLocation,
             ParallelRunId = request.ParallelRunId,
+            BatchId = request.BatchId,
             BatchSequenceNumber = request.BatchSequenceNumber,
         };
 
         await resultPublisher.PublishWithSession(batchResult, sessionId: request.SearchRequestId);
 
         logger.LogInformation(
-            "Published batch result for search {SearchRequestId} (session) to parallel-match-prediction-results",
-            request.SearchRequestId
+            "Published batch result for batch {BatchId}, search {SearchRequestId} (session) to parallel-match-prediction-results",
+            request.BatchId, request.SearchRequestId
         );
     }
 }

--- a/Atlas.MatchPrediction/ExternalInterface/DependencyInjection/ServiceConfiguration.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/DependencyInjection/ServiceConfiguration.cs
@@ -210,6 +210,7 @@ namespace Atlas.MatchPrediction.ExternalInterface.DependencyInjection
             services.AddScoped<IGenotypeConverter, GenotypeConverter>();
 
             services.AddScoped<ISearchDonorResultUploader, SearchDonorResultUploader>();
+            services.AddScoped<IMatchPredictionBatchResultUploader, MatchPredictionBatchResultUploader>();
         }
     }
 }

--- a/Atlas.MatchPrediction/ExternalInterface/Models/ParallelMatchPredictionBatchRequest.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/Models/ParallelMatchPredictionBatchRequest.cs
@@ -22,8 +22,11 @@ public class ParallelMatchPredictionBatchRequest
     public int ParallelRunId { get; set; }
 
     /// <summary>
-    /// Zero-based sequence number of this batch within the parallel run. Together with <see cref="ParallelRunId"/>
-    /// forms the idempotency key used by the aggregator when persisting per-batch results.
+    /// Id of the pre-created <c>ParallelMatchPredictionBatch</c> row. The Worker names the output blob after it and
+    /// echoes it back on the result; the aggregator keys per-batch persistence on it.
     /// </summary>
+    public int BatchId { get; set; }
+
+    /// <summary>Zero-based sequence number of this batch within the run. Retained for logging and ordering.</summary>
     public int BatchSequenceNumber { get; set; }
 }

--- a/Atlas.MatchPrediction/ExternalInterface/Models/ParallelMatchPredictionBatchResult.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/Models/ParallelMatchPredictionBatchResult.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Atlas.MatchPrediction.ExternalInterface.Models;
 
 /// <summary>
 /// Message published to the <c>parallel-match-prediction-results</c> Service Bus topic by the ACA Worker.
 /// Session ID is set to <see cref="SearchIdentifier"/> so the aggregator can hold an exclusive lock per search.
-/// When <see cref="IsSuccessful"/> is <c>false</c> the batch failed; <see cref="MatchPredictionResultLocations"/>
-/// will be empty and <see cref="FailureMessage"/>/<see cref="FailureException"/> will be populated.
+/// When <see cref="IsSuccessful"/> is <c>false</c> the batch failed; <see cref="MatchPredictionResultLocation"/>
+/// will be <c>null</c> and <see cref="FailureMessage"/>/<see cref="FailureException"/> will be populated.
 /// </summary>
 public class ParallelMatchPredictionBatchResult
 {
@@ -19,19 +18,18 @@ public class ParallelMatchPredictionBatchResult
     public bool IsSuccessful { get; set; } = true;
 
     /// <summary>
-    /// Keyed by Atlas donor ID; values are blob filenames (relative to the match-prediction-results container)
-    /// where per-donor match probability results can be found.
-    /// Populated only when <see cref="IsSuccessful"/> is <c>true</c>.
+    /// Blob filename of the single file holding this batch's donor → match probability result map. Populated only
+    /// when <see cref="IsSuccessful"/> is <c>true</c> (<c>null</c> for a batch that contained no donors).
     /// </summary>
-    public IReadOnlyDictionary<int, string> MatchPredictionResultLocations { get; set; }
+    public string MatchPredictionResultLocation { get; set; }
 
     /// <summary>Id of the parent <c>ParallelMatchPredictionRun</c> row.</summary>
     public int ParallelRunId { get; set; }
 
-    /// <summary>
-    /// Sequence number of this batch as assigned by the orchestrator. Together with <see cref="ParallelRunId"/>
-    /// forms the idempotency key used by the aggregator.
-    /// </summary>
+    /// <summary>Id of the <c>ParallelMatchPredictionBatch</c> row this result belongs to; the aggregator's persistence key.</summary>
+    public int BatchId { get; set; }
+
+    /// <summary>Sequence number of this batch within the run. Retained for logging and ordering.</summary>
     public int BatchSequenceNumber { get; set; }
 
     /// <summary>

--- a/Atlas.MatchPrediction/ExternalInterface/ParallelMatchPredictionAlgorithm.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ParallelMatchPredictionAlgorithm.cs
@@ -28,13 +28,13 @@ namespace Atlas.MatchPrediction.ExternalInterface
     internal class ParallelMatchPredictionAlgorithm : IParallelMatchPredictionAlgorithm
     {
         private readonly IGenotypeSetService genotypeSetService;
-        private readonly ISearchDonorResultUploader resultUploader;
+        private readonly IMatchPredictionBatchResultUploader resultUploader;
         private readonly IServiceScopeFactory serviceScopeFactory;
         private readonly IAtlasLogger logger;
 
         public ParallelMatchPredictionAlgorithm(
             IGenotypeSetService genotypeSetService,
-            ISearchDonorResultUploader resultUploader,
+            IMatchPredictionBatchResultUploader resultUploader,
             // ReSharper disable once SuggestBaseTypeForParameterInConstructor
             IMatchPredictionLogger<MatchProbabilityLoggingContext> logger,
             IServiceScopeFactory serviceScopeFactory)
@@ -80,7 +80,7 @@ namespace Atlas.MatchPrediction.ExternalInterface
                     .SelectMany(donorResults => donorResults)
                     .ToDictionary(kv => kv.Key, kv => kv.Value);
 
-                return await resultUploader.UploadBatchResult(searchRequestId, batchId, resultsByDonorId);
+                return await resultUploader.UploadMatchPredictionBatchResult(searchRequestId, batchId, resultsByDonorId);
             }
         }
     }

--- a/Atlas.MatchPrediction/ExternalInterface/ParallelMatchPredictionAlgorithm.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ParallelMatchPredictionAlgorithm.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Atlas.Client.Models.Search.Results.MatchPrediction;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.ApplicationInsights.Timing;
 using Atlas.Common.Utils.Concurrency;
-using Atlas.Common.Utils.Extensions;
 using Atlas.MatchPrediction.ApplicationInsights;
 using Atlas.MatchPrediction.ExternalInterface.Models.MatchProbability;
 using Atlas.MatchPrediction.ExternalInterface.ResultsUpload;
@@ -15,32 +15,40 @@ namespace Atlas.MatchPrediction.ExternalInterface
 {
     public interface IParallelMatchPredictionAlgorithm
     {
-        /// <returns>A dictionary of donorId:filenames in blob storage where the per-donor results can be located.</returns>
-        Task<IReadOnlyDictionary<int, string>> RunBatch(
+        /// <summary>
+        /// Runs match prediction for every donor in the batch and stores the whole batch's results in a single blob.
+        /// </summary>
+        /// <returns>The blob filename holding the batch's donor → result map, or <c>null</c> when the batch has no donors.</returns>
+        Task<string> RunBatch(
             MultipleDonorMatchProbabilityInput multipleDonorMatchProbabilityInput,
-            int maxDegreeOfParallelism);
+            int maxDegreeOfParallelism,
+            int batchId);
     }
 
     internal class ParallelMatchPredictionAlgorithm : IParallelMatchPredictionAlgorithm
     {
         private readonly IGenotypeSetService genotypeSetService;
+        private readonly ISearchDonorResultUploader resultUploader;
         private readonly IServiceScopeFactory serviceScopeFactory;
         private readonly IAtlasLogger logger;
 
         public ParallelMatchPredictionAlgorithm(
             IGenotypeSetService genotypeSetService,
+            ISearchDonorResultUploader resultUploader,
             // ReSharper disable once SuggestBaseTypeForParameterInConstructor
             IMatchPredictionLogger<MatchProbabilityLoggingContext> logger,
             IServiceScopeFactory serviceScopeFactory)
         {
             this.genotypeSetService = genotypeSetService;
+            this.resultUploader = resultUploader;
             this.logger = logger;
             this.serviceScopeFactory = serviceScopeFactory;
         }
 
-        public async Task<IReadOnlyDictionary<int, string>> RunBatch(
+        public async Task<string> RunBatch(
             MultipleDonorMatchProbabilityInput multipleDonorMatchProbabilityInput,
-            int maxDegreeOfParallelism)
+            int maxDegreeOfParallelism,
+            int batchId)
         {
             using (logger.RunLongOperationWithTimer("Run Match Prediction Algorithm Batch (Parallel)", new LongLoggingSettings()))
             {
@@ -48,7 +56,7 @@ namespace Atlas.MatchPrediction.ExternalInterface
                 var matchProbabilityInputs = multipleDonorMatchProbabilityInput.SingleDonorMatchProbabilityInputs.ToList();
                 if (matchProbabilityInputs.Count == 0)
                 {
-                    return new Dictionary<int, string>();
+                    return null;
                 }
 
                 var patientGenotypeSet = await genotypeSetService.GetPatientGenotypeSet(matchProbabilityInputs.First());
@@ -58,19 +66,21 @@ namespace Atlas.MatchPrediction.ExternalInterface
                     {
                         await using var scope = serviceScopeFactory.CreateAsyncScope();
                         var scopedMatchProbabilityService = scope.ServiceProvider.GetRequiredService<IMatchProbabilityService>();
-                        var scopedResultUploader = scope.ServiceProvider.GetRequiredService<ISearchDonorResultUploader>();
                         var scopedLogger = scope.ServiceProvider.GetRequiredService<IMatchPredictionLogger<MatchProbabilityLoggingContext>>();
 
                         using (scopedLogger.RunTimed("Run Match Prediction Algorithm per donor (parallel)"))
                         {
                             var result = await scopedMatchProbabilityService.CalculateMatchProbability(input, patientGenotypeSet);
-                            return await scopedResultUploader.UploadSearchDonorResults(searchRequestId, input.Donor.DonorIds, result);
+                            return input.Donor.DonorIds.Select(donorId => new KeyValuePair<int, MatchProbabilityResponse>(donorId, result));
                         }
                     },
                     maxDegreeOfParallelism);
 
-                return perDonorResults
-                    .Aggregate(new Dictionary<int, string>(), (fileNames, d) => fileNames.Merge(d));
+                var resultsByDonorId = perDonorResults
+                    .SelectMany(donorResults => donorResults)
+                    .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+                return await resultUploader.UploadBatchResult(searchRequestId, batchId, resultsByDonorId);
             }
         }
     }

--- a/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/MatchPredictionBatchResultUploader.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/MatchPredictionBatchResultUploader.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Atlas.Client.Models.Search.Results.MatchPrediction;
+using Atlas.Common.ApplicationInsights;
+using Atlas.Common.ApplicationInsights.Timing;
+using Atlas.MatchPrediction.ExternalInterface.Settings;
+
+namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
+{
+    internal interface IMatchPredictionBatchResultUploader
+    {
+        /// <summary>
+        /// Uploads a whole parallel batch's match probability results into a single blob, keyed by Atlas donor id and
+        /// named after the batch id.
+        /// </summary>
+        /// <returns>The blob filename where the batch results were stored.</returns>
+        Task<string> UploadMatchPredictionBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId);
+    }
+
+    internal class MatchPredictionBatchResultUploader : MatchProbabilityResultUploader, IMatchPredictionBatchResultUploader
+    {
+        public MatchPredictionBatchResultUploader(AzureStorageSettings azureStorageSettings, IAtlasLogger logger) : base(azureStorageSettings, logger)
+        {
+        }
+
+        public async Task<string> UploadMatchPredictionBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId)
+        {
+            var fileName = $"{searchRequestId}/match-prediction-batch-{batchId}.json";
+            using (logger.RunTimed("Uploading match prediction batch results", LogLevel.Verbose))
+            {
+                await Upload(ResultsContainer, fileName, resultsByDonorId);
+            }
+
+            return fileName;
+        }
+    }
+}

--- a/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/MatchProbabilityResultUploader.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/MatchProbabilityResultUploader.cs
@@ -35,5 +35,13 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
                 await UploadMultiple(ResultsContainer, fileNames.Select(f => new KeyValuePair<string, MatchProbabilityResponse>(f, matchProbabilityResponse)).ToDictionary());
             }
         }
+
+        protected async Task UploadBatchResults(string fileName, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId)
+        {
+            using (logger.RunTimed("Uploading match prediction batch results", LogLevel.Verbose))
+            {
+                await Upload(ResultsContainer, fileName, resultsByDonorId);
+            }
+        }
     }
 }

--- a/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/MatchProbabilityResultUploader.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/MatchProbabilityResultUploader.cs
@@ -35,13 +35,5 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
                 await UploadMultiple(ResultsContainer, fileNames.Select(f => new KeyValuePair<string, MatchProbabilityResponse>(f, matchProbabilityResponse)).ToDictionary());
             }
         }
-
-        protected async Task UploadBatchResults(string fileName, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId)
-        {
-            using (logger.RunTimed("Uploading match prediction batch results", LogLevel.Verbose))
-            {
-                await Upload(ResultsContainer, fileName, resultsByDonorId);
-            }
-        }
     }
 }

--- a/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/SearchDonorResultUploader.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/SearchDonorResultUploader.cs
@@ -39,7 +39,7 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
 
         public async Task<string> UploadBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId)
         {
-            var fileName = $"{searchRequestId}/{batchId}.json";
+            var fileName = $"{searchRequestId}/batch-{batchId}.json";
             await UploadBatchResults(fileName, resultsByDonorId);
             return fileName;
         }

--- a/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/SearchDonorResultUploader.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/SearchDonorResultUploader.cs
@@ -15,6 +15,13 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
         /// </summary>
         /// <returns>List of filenames of results files</returns>
         Task<Dictionary<int, string>> UploadSearchDonorResults(string searchRequestId, IEnumerable<int> atlasDonorIds, MatchProbabilityResponse matchProbabilityResponse);
+
+        /// <summary>
+        /// Uploads a whole parallel batch's match probability results into a single blob, keyed by Atlas donor id and
+        /// named after the batch id.
+        /// </summary>
+        /// <returns>The blob filename where the batch results were stored.</returns>
+        Task<string> UploadBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId);
     }
 
     internal class SearchDonorResultUploader : MatchProbabilityResultUploader, ISearchDonorResultUploader
@@ -28,6 +35,13 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
             var fileNames = atlasDonorIds.Select(id => new KeyValuePair<int, string> (id, $"{searchRequestId}/{id}.json") ).ToDictionary();
             await UploadResults(fileNames.Select(f => f.Value), matchProbabilityResponse);
             return fileNames;
+        }
+
+        public async Task<string> UploadBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId)
+        {
+            var fileName = $"{searchRequestId}/{batchId}.json";
+            await UploadBatchResults(fileName, resultsByDonorId);
+            return fileName;
         }
     }
 }

--- a/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/SearchDonorResultUploader.cs
+++ b/Atlas.MatchPrediction/ExternalInterface/ResultsUpload/SearchDonorResultUploader.cs
@@ -15,13 +15,6 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
         /// </summary>
         /// <returns>List of filenames of results files</returns>
         Task<Dictionary<int, string>> UploadSearchDonorResults(string searchRequestId, IEnumerable<int> atlasDonorIds, MatchProbabilityResponse matchProbabilityResponse);
-
-        /// <summary>
-        /// Uploads a whole parallel batch's match probability results into a single blob, keyed by Atlas donor id and
-        /// named after the batch id.
-        /// </summary>
-        /// <returns>The blob filename where the batch results were stored.</returns>
-        Task<string> UploadBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId);
     }
 
     internal class SearchDonorResultUploader : MatchProbabilityResultUploader, ISearchDonorResultUploader
@@ -35,13 +28,6 @@ namespace Atlas.MatchPrediction.ExternalInterface.ResultsUpload
             var fileNames = atlasDonorIds.Select(id => new KeyValuePair<int, string> (id, $"{searchRequestId}/{id}.json") ).ToDictionary();
             await UploadResults(fileNames.Select(f => f.Value), matchProbabilityResponse);
             return fileNames;
-        }
-
-        public async Task<string> UploadBatchResult(string searchRequestId, int batchId, IReadOnlyDictionary<int, MatchProbabilityResponse> resultsByDonorId)
-        {
-            var fileName = $"{searchRequestId}/batch-{batchId}.json";
-            await UploadBatchResults(fileName, resultsByDonorId);
-            return fileName;
         }
     }
 }


### PR DESCRIPTION
Rewrites the parallel Match Prediction Worker to collect each batch's donor results into a single blob (named after the batch id) instead of one file per donor. BatchId is now threaded through the whole flow: request, result notification, and DB  and used as the key for recording and finalising batch results (replacing the serialised donor→location dictionary with a single ResultLocation path)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1476)
<!-- Reviewable:end -->
