### PR TITLE
feature: ATL-149: alert & propagate batch-worker failures on parallel…

### DIFF
--- a/Atlas.Functions.Test/Services/ParallelMatchPredictionCompletionServiceTests.cs
+++ b/Atlas.Functions.Test/Services/ParallelMatchPredictionCompletionServiceTests.cs
@@ -211,7 +211,45 @@ namespace Atlas.Functions.Test.Services
             await repository.Received(1).MarkRunFailed(runId, Arg.Any<DateTime>());
         }
 
-        private ParallelMatchPredictionRunResults RunResults(ParallelMatchPredictionRunStatus status, bool failedBatch)
+        [Test]
+        public async Task FinaliseRun_FailedRunThatWasNotAbandoned_RaisesHighPriorityAlert()
+        {
+            var runId = fixture.Create<int>();
+            repository.GetRunWithResults(runId).Returns(RunResults(
+                status: ParallelMatchPredictionRunStatus.Running,
+                failedBatch: true
+            ));
+
+            await completionService.FinaliseRun(runId);
+
+            await notificationSender.Received(1).SendAlert(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Priority.High,
+                Arg.Any<string>()
+            );
+        }
+
+        [Test]
+        public async Task FinaliseRun_FailedRun_PublishesFailureDetailCarryingBatchReason()
+        {
+            var runId = fixture.Create<int>();
+            var batchFailureMessage = fixture.Create<string>();
+            repository.GetRunWithResults(runId).Returns(RunResults(
+                status: ParallelMatchPredictionRunStatus.Running,
+                failedBatch: true,
+                batchFailureMessage: batchFailureMessage
+            ));
+
+            await completionService.FinaliseRun(runId);
+
+            await searchCompletionMessageSender.Received(1).PublishFailureMessage(
+                Arg.Is<SendFailureNotificationParameters>(p => p.FailureDetail.Contains(batchFailureMessage))
+            );
+        }
+
+        private ParallelMatchPredictionRunResults RunResults(
+            ParallelMatchPredictionRunStatus status, bool failedBatch, string batchFailureMessage = null)
         {
             return new ParallelMatchPredictionRunResults
             {
@@ -232,7 +270,7 @@ namespace Atlas.Functions.Test.Services
                         {
                             BatchSequenceNumber = 0,
                             BatchStatus = ParallelMatchPredictionBatchStatus.Failed,
-                            FailureMessage = fixture.Create<string>(),
+                            FailureMessage = batchFailureMessage ?? fixture.Create<string>(),
                             FailureException = fixture.Create<string>(),
                         }
                     }

--- a/Atlas.Functions/Services/ParallelMatchPredictionCompletionService.cs
+++ b/Atlas.Functions/Services/ParallelMatchPredictionCompletionService.cs
@@ -297,14 +297,15 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
         );
 
         logger.SendTrace(
-            $"Failure notification sent for search {run.SearchIdentifier}: {failureMessage}",
+            $"Failure notification sent for search {run.SearchIdentifier}: {failureDetail}",
             LogLevel.Error
         );
 
         // Raise an operational alert so a batch-worker failure does not fail silently for support.
         await notificationSender.SendAlert(
             $"Parallel match prediction failed for search {run.SearchIdentifier}",
-            $"{failureMessage} (parallel run id: {runId}). Full exception detail has been logged to Application Insights.",
+            $"{failureMessage} (parallel run id: {runId}). Full exception detail is available in Application Insights "
+          + "and in Search Tracking (match-prediction completion FailureInfo.ExceptionStacktrace).",
             Priority.High,
             ParallelMatchPredictionNotificationSource
         );

--- a/Atlas.Functions/Services/ParallelMatchPredictionCompletionService.cs
+++ b/Atlas.Functions/Services/ParallelMatchPredictionCompletionService.cs
@@ -74,7 +74,7 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
     private readonly AzureStorageSettings azureStorageSettings;
     private readonly int parallelMatchPredictionBatchSize;
 
-    private const string AbandonmentNotificationSource = "Atlas.Functions.ParallelMatchPrediction";
+    private const string ParallelMatchPredictionNotificationSource = "Atlas.Functions.ParallelMatchPrediction";
     private const string MatchPredictionBatchProcessingStage = "MatchPredictionBatchProcessing";
 
     public ParallelMatchPredictionCompletionService(
@@ -201,7 +201,7 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
             $"Parallel match prediction run abandoned (search {header.SearchIdentifier})",
             failureMessage,
             Priority.Medium,
-            AbandonmentNotificationSource
+            ParallelMatchPredictionNotificationSource
         );
 
         logger.SendTrace(
@@ -277,19 +277,36 @@ public class ParallelMatchPredictionCompletionService : IParallelMatchPrediction
             )
         );
 
+        var batchFailureReasons = runResults.FailedBatches
+            .Select(b => b.FailureMessage)
+            .Where(m => !string.IsNullOrWhiteSpace(m))
+            .Distinct()
+            .ToList();
+        var failureDetail = batchFailureReasons.Count > 0
+            ? $"{failureMessage} Reason(s): {string.Join("; ", batchFailureReasons)}"
+            : failureMessage;
+
         // Emit failure notification, carrying the failure detail in the shared payload.
         await searchCompletionMessageSender.PublishFailureMessage(new SendFailureNotificationParameters
             {
                 SearchRequestId = run.SearchIdentifier.ToString(),
                 RepeatSearchRequestId = run.RepeatSearchIdentifier?.ToString(),
                 StageReached = MatchPredictionBatchProcessingStage,
-                FailureDetail = failureMessage,
+                FailureDetail = failureDetail,
             }
         );
 
         logger.SendTrace(
             $"Failure notification sent for search {run.SearchIdentifier}: {failureMessage}",
             LogLevel.Error
+        );
+
+        // Raise an operational alert so a batch-worker failure does not fail silently for support.
+        await notificationSender.SendAlert(
+            $"Parallel match prediction failed for search {run.SearchIdentifier}",
+            $"{failureMessage} (parallel run id: {runId}). Full exception detail has been logged to Application Insights.",
+            Priority.High,
+            ParallelMatchPredictionNotificationSource
         );
 
         await repository.MarkRunFailed(runId, DateTime.UtcNow);

--- a/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
+++ b/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
@@ -45,7 +45,7 @@ public class MatchPredictionWorker(
 
             if (request is null)
             {
-                throw new InvalidOperationException("Parallel match prediction batch request could not be deserialized (null body).");
+                throw new InvalidOperationException("Parallel match prediction batch request deserialized to null.");
             }
 
             await using var scope = serviceScopeFactory.CreateAsyncScope();

--- a/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
+++ b/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
@@ -35,22 +35,29 @@ public class MatchPredictionWorker(
 
     private async Task ProcessMessageAsync(ProcessMessageEventArgs args)
     {
-        var request = JsonConvert.DeserializeObject<ParallelMatchPredictionBatchRequest>(
-            Encoding.UTF8.GetString(args.Message.Body)
-        );
-
         try
         {
+            // Deserialize inside the try so a malformed message body is abandoned (and eventually dead-lettered
+            // once the subscription's max delivery count is exceeded) rather than escaping uncaught.
+            var request = JsonConvert.DeserializeObject<ParallelMatchPredictionBatchRequest>(
+                Encoding.UTF8.GetString(args.Message.Body)
+            );
+
+            if (request is null)
+            {
+                throw new InvalidOperationException("Parallel match prediction batch request could not be deserialized (null body).");
+            }
+
             await using var scope = serviceScopeFactory.CreateAsyncScope();
             var runner = scope.ServiceProvider.GetRequiredService<IParallelMatchPredictionBatchRunner>();
 
-            await runner.RunBatch(request!);
+            await runner.RunBatch(request);
 
             await args.CompleteMessageAsync(args.Message, args.CancellationToken);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Unexpected error processing parallel match prediction batch — abandoning message.");
+            logger.LogError(ex, "Unexpected error processing parallel match prediction batch — abandoning message for redelivery/dead-lettering.");
             await args.AbandonMessageAsync(args.Message, cancellationToken: args.CancellationToken);
         }
     }

--- a/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
+++ b/Atlas.MatchPrediction.Worker/MatchPredictionWorker.cs
@@ -37,8 +37,10 @@ public class MatchPredictionWorker(
     {
         try
         {
-            // Deserialize inside the try so a malformed message body is abandoned (and eventually dead-lettered
-            // once the subscription's max delivery count is exceeded) rather than escaping uncaught.
+            // we don't expect a malformed body: every message on this topic is produced by our own
+            // orchestrator, and nothing writes to the queue by hand. Deserializing inside the try is defensive,
+            // should a bad body ever appear it is abandoned (and eventually dead-lettered once the
+            // subscription's max delivery count is exceeded) rather than escaping uncaught.
             var request = JsonConvert.DeserializeObject<ParallelMatchPredictionBatchRequest>(
                 Encoding.UTF8.GetString(args.Message.Body)
             );

--- a/Atlas.SearchTracking.Data.Test/Repositories/MatchPredictionRepositoryTests.cs
+++ b/Atlas.SearchTracking.Data.Test/Repositories/MatchPredictionRepositoryTests.cs
@@ -120,6 +120,43 @@ namespace Atlas.SearchTracking.Data.Test.Repositories
                 .Excluding(a => a.SearchRequest));
         }
 
+        [Test]
+        public async Task TrackMatchPredictionCompletedEvent_WhenFailed_PersistsFailureInfoToDb()
+        {
+            await CreateDefaultMatchPrediction();
+            var expectedMatchPredictionEntity = MatchPredictionEntityBuilder.Completed
+                .With(m => m.IsSuccessful, false)
+                .With(m => m.FailureInfo_Type, MatchPredictionFailureType.BatchWorkerFailure)
+                .With(m => m.FailureInfo_Message, "2 out of 3 match prediction batch(es) failed during processing.")
+                .With(m => m.FailureInfo_ExceptionStacktrace, "System.Exception: batch worker failed\n---\nSystem.Exception: batch worker failed")
+                .Build();
+
+            var expectedSearchRequestGuid = new Guid("aaaaaaaa-bbbb-cccc-dddd-000000000000");
+
+            var matchPredictionCompletedEvent = new MatchPredictionCompletedEvent
+            {
+                SearchIdentifier = expectedSearchRequestGuid,
+                CompletionTimeUtc = expectedMatchPredictionEntity.CompletionTimeUtc.Value,
+                CompletionDetails = new MatchPredictionCompletionDetails
+                {
+                    IsSuccessful = false,
+                    FailureInfo = new MatchPredictionFailureInfo
+                    {
+                        Type = expectedMatchPredictionEntity.FailureInfo_Type,
+                        Message = expectedMatchPredictionEntity.FailureInfo_Message,
+                        ExceptionStacktrace = expectedMatchPredictionEntity.FailureInfo_ExceptionStacktrace,
+                    }
+                }
+            };
+
+            await matchPredictionRepository.TrackCompletedEvent(matchPredictionCompletedEvent);
+
+            var actualMatchPredictionEntity = await matchPredictionRepository.GetSearchRequestMatchPredictionById(expectedMatchPredictionEntity.SearchRequestId);
+
+            expectedMatchPredictionEntity.Should().BeEquivalentTo(actualMatchPredictionEntity, options => options
+                .Excluding(a => a.SearchRequest));
+        }
+
         private async Task CreateDefaultMatchPrediction()
         {
             var matchPrediction = MatchPredictionEntityBuilder.Default.Build();

--- a/Atlas.SearchTracking.Data.Test/Repositories/MatchPredictionRepositoryTests.cs
+++ b/Atlas.SearchTracking.Data.Test/Repositories/MatchPredictionRepositoryTests.cs
@@ -5,6 +5,7 @@ using Atlas.SearchTracking.Data.Models;
 using Atlas.SearchTracking.Data.Repositories;
 using Atlas.SearchTracking.Data.Test.Builders;
 using Atlas.SearchTracking.Data.Test.TestHelpers;
+using AutoFixture;
 using AwesomeAssertions;
 using NUnit.Framework;
 
@@ -15,6 +16,7 @@ namespace Atlas.SearchTracking.Data.Test.Repositories
     {
         private IMatchPredictionRepository matchPredictionRepository;
         private SearchRequestMatchPrediction defaultMatchPrediction;
+        private Fixture fixture;
 
         [SetUp]
         public async Task SetUp()
@@ -23,6 +25,7 @@ namespace Atlas.SearchTracking.Data.Test.Repositories
             matchPredictionRepository = new MatchPredictionRepository(SearchTrackingContext);
             await InitiateData();
             defaultMatchPrediction = MatchPredictionEntityBuilder.Default.Build();
+            fixture = new Fixture();
         }
 
         [TearDown]
@@ -127,8 +130,8 @@ namespace Atlas.SearchTracking.Data.Test.Repositories
             var expectedMatchPredictionEntity = MatchPredictionEntityBuilder.Completed
                 .With(m => m.IsSuccessful, false)
                 .With(m => m.FailureInfo_Type, MatchPredictionFailureType.BatchWorkerFailure)
-                .With(m => m.FailureInfo_Message, "2 out of 3 match prediction batch(es) failed during processing.")
-                .With(m => m.FailureInfo_ExceptionStacktrace, "System.Exception: batch worker failed\n---\nSystem.Exception: batch worker failed")
+                .With(m => m.FailureInfo_Message, fixture.Create<string>())
+                .With(m => m.FailureInfo_ExceptionStacktrace, fixture.Create<string>())
                 .Build();
 
             var expectedSearchRequestGuid = new Guid("aaaaaaaa-bbbb-cccc-dddd-000000000000");

--- a/Atlas.SearchTracking.Data/Repositories/MatchPredictionRepository.cs
+++ b/Atlas.SearchTracking.Data/Repositories/MatchPredictionRepository.cs
@@ -50,9 +50,13 @@ namespace Atlas.SearchTracking.Data.Repositories
             var id = await GetSearchRequestIdByIdentifier(matchPredictionCompletedEvent.SearchIdentifier);
 
             var matchPrediction = await GetRequiredMatchPredictionTiming(id);
+            var completionDetails = matchPredictionCompletedEvent.CompletionDetails;
 
             matchPrediction.CompletionTimeUtc = matchPredictionCompletedEvent.CompletionTimeUtc;
-            matchPrediction.IsSuccessful = matchPredictionCompletedEvent.CompletionDetails.IsSuccessful;
+            matchPrediction.IsSuccessful = completionDetails.IsSuccessful;
+            matchPrediction.FailureInfo_Message = completionDetails.FailureInfo?.Message;
+            matchPrediction.FailureInfo_ExceptionStacktrace = completionDetails.FailureInfo?.ExceptionStacktrace;
+            matchPrediction.FailureInfo_Type = completionDetails.FailureInfo?.Type;
             await context.SaveChangesAsync();
         }
 


### PR DESCRIPTION
Surfaces parallel match-prediction batch-worker failures: the worker now abandons/dead-letters failed messages reliably, the function raises an alert and propagates the batch failure reason into the search-results-ready payload, and search tracking persists the failure message, stacktrace and type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1481)
<!-- Reviewable:end -->
