### PR TITLE
fix: ATL-279: use app_scale_limit instead of unreliable scale-out app setting

### DIFF
--- a/terraform/core/modules/donor_import/function.tf
+++ b/terraform/core/modules/donor_import/function.tf
@@ -81,7 +81,8 @@ resource "azurerm_windows_function_app" "atlas_donor_import_function" {
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
 
-    app_scale_limit = var.MAX_INSTANCES
+    pre_warmed_instance_count = 1
+    app_scale_limit           = var.MAX_INSTANCES
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/donor_import/function.tf
+++ b/terraform/core/modules/donor_import/function.tf
@@ -59,8 +59,7 @@ resource "azurerm_windows_function_app" "atlas_donor_import_function" {
     "FailureLogs:DeletionCronSchedule" = var.FAILURE_LOGS_CRONTAB
     "FailureLogs:ExpiryInDays"         = var.FAILURE_LOGS_EXPIRY_IN_DAYS
 
-    "WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT" = var.MAX_INSTANCES
-    "WEBSITE_RUN_FROM_PACKAGE"                  = "1"
+    "WEBSITE_RUN_FROM_PACKAGE" = "1"
   }
 
   site_config {
@@ -81,6 +80,8 @@ resource "azurerm_windows_function_app" "atlas_donor_import_function" {
 
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
+
+    app_scale_limit = var.MAX_INSTANCES
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/match_prediction/function.tf
+++ b/terraform/core/modules/match_prediction/function.tf
@@ -65,7 +65,8 @@ resource "azurerm_windows_function_app" "atlas_match_prediction_function" {
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
 
-    app_scale_limit = 1
+    pre_warmed_instance_count = 1
+    app_scale_limit           = 1
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/match_prediction/function.tf
+++ b/terraform/core/modules/match_prediction/function.tf
@@ -43,8 +43,7 @@ resource "azurerm_windows_function_app" "atlas_match_prediction_function" {
     "NotificationsServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
     "NotificationsServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT" = "1"
-    "WEBSITE_RUN_FROM_PACKAGE"                  = var.WEBSITE_RUN_FROM_PACKAGE
+    "WEBSITE_RUN_FROM_PACKAGE" = var.WEBSITE_RUN_FROM_PACKAGE
   }
 
   site_config {
@@ -65,6 +64,8 @@ resource "azurerm_windows_function_app" "atlas_match_prediction_function" {
 
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
+
+    app_scale_limit = 1
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/matching_algorithm/donor_management_function.tf
+++ b/terraform/core/modules/matching_algorithm/donor_management_function.tf
@@ -19,14 +19,13 @@ locals {
     "MessagingServiceBus:SendRetryCount"                                                            = var.SERVICE_BUS_SEND_RETRY_COUNT
     "MessagingServiceBus:SendRetryCooldownSeconds"                                                  = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "NotificationsServiceBus:ConnectionString"           = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
-    "NotificationsServiceBus:AlertsTopic"                = var.servicebus_topics.alerts.name
-    "NotificationsServiceBus:NotificationsTopic"         = var.servicebus_topics.notifications.name
-    "NotificationsServiceBus:SendRetryCount"             = var.SERVICE_BUS_SEND_RETRY_COUNT
-    "NotificationsServiceBus:SendRetryCooldownSeconds"   = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
+    "NotificationsServiceBus:ConnectionString"         = var.servicebus_namespace_authorization_rules.write-only.primary_connection_string
+    "NotificationsServiceBus:AlertsTopic"              = var.servicebus_topics.alerts.name
+    "NotificationsServiceBus:NotificationsTopic"       = var.servicebus_topics.notifications.name
+    "NotificationsServiceBus:SendRetryCount"           = var.SERVICE_BUS_SEND_RETRY_COUNT
+    "NotificationsServiceBus:SendRetryCooldownSeconds" = var.SERVICE_BUS_SEND_RETRY_COOLDOWN_SECONDS
 
-    "WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT" = "1"
-    "WEBSITE_RUN_FROM_PACKAGE"                  = var.WEBSITE_RUN_FROM_PACKAGE
+    "WEBSITE_RUN_FROM_PACKAGE" = var.WEBSITE_RUN_FROM_PACKAGE
   }
   donor_management_function_app_name = "${var.general.environment}-ATLAS-MATCHING-DONOR-MANAGEMENT-FUNCTION"
 }
@@ -60,6 +59,8 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_donor_manageme
 
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
+
+    app_scale_limit = 1
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/matching_algorithm/donor_management_function.tf
+++ b/terraform/core/modules/matching_algorithm/donor_management_function.tf
@@ -60,7 +60,8 @@ resource "azurerm_windows_function_app" "atlas_matching_algorithm_donor_manageme
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
 
-    app_scale_limit = 1
+    pre_warmed_instance_count = 1
+    app_scale_limit           = 1
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/repeat_search/function.tf
+++ b/terraform/core/modules/repeat_search/function.tf
@@ -81,7 +81,8 @@ resource "azurerm_windows_function_app" "atlas_repeat_search_function" {
     // maximum running instances of the algorithm = maximum_worker_count * maxConcurrentCalls (in host.json).
     // together, alongside the non-repeat matching processes, these must ensure that the number of allowed concurrent SQL connections to the matching SQL DB is not exceeded.
     // See README_Integration.md for more details on concurrency configuration.
-    app_scale_limit = var.MAX_SCALE_OUT
+    pre_warmed_instance_count = 1
+    app_scale_limit           = var.MAX_SCALE_OUT
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"

--- a/terraform/core/modules/repeat_search/function.tf
+++ b/terraform/core/modules/repeat_search/function.tf
@@ -56,11 +56,7 @@ resource "azurerm_windows_function_app" "atlas_repeat_search_function" {
     "StoreOriginalSearchResultsBulkCopy:BatchSize"             = var.STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_BATCHSIZE
     "StoreOriginalSearchResultsBulkCopy:Timeout"               = var.STORE_ORIGINAL_SEARCH_RESULTS_BULKCOPY_TIMEOUT
 
-    // maximum running instances of the algorithm = maximum_worker_count * maxConcurrentCalls (in host.json).
-    // together, alongside the non-repeat matching processes, these must ensure that the number of allowed concurrent SQL connections to the matching SQL DB is not exceeded.
-    // See README_Integration.md for more details on concurrency configuration.
-    "WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT" = var.MAX_SCALE_OUT
-    "WEBSITE_RUN_FROM_PACKAGE"                  = "1"
+    "WEBSITE_RUN_FROM_PACKAGE" = "1"
   }
 
   site_config {
@@ -81,6 +77,11 @@ resource "azurerm_windows_function_app" "atlas_repeat_search_function" {
 
     health_check_path                 = "/api/HealthCheck"
     health_check_eviction_time_in_min = 10
+
+    // maximum running instances of the algorithm = maximum_worker_count * maxConcurrentCalls (in host.json).
+    // together, alongside the non-repeat matching processes, these must ensure that the number of allowed concurrent SQL connections to the matching SQL DB is not exceeded.
+    // See README_Integration.md for more details on concurrency configuration.
+    app_scale_limit = var.MAX_SCALE_OUT
 
     ftps_state              = "AllAllowed"
     scm_minimum_tls_version = "1.2"


### PR DESCRIPTION
## Summary
- Root cause of the DEV cost spike (ATL-279): `WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT` is not reliably enforced by the Azure Functions host, which is why DEV's `DEV-ATLAS-REPEAT-SEARCH-FUNCTION` scaled out to 50 instances during a perf test instead of respecting `REPEAT_SEARCH_MATCHING_MAX_SCALE_OUT`.
- Moves the scale-out limit from the `WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT` app setting to the `site_config.app_scale_limit` property (which is actually enforced), mirroring the pattern already used by `matching_algorithm_function.tf`.
- Applied to all 4 Function Apps in `terraform/core` still using the old setting, per the ticket's fix/prevention point 1a: `repeat_search`, `matching_algorithm/donor_management`, `match_prediction`, `donor_import`.
- Confirmed via repo-wide grep that no `WEBSITE_MAX_DYNAMIC_APPLICATION_SCALE_OUT` references remain in `terraform/`.

Jira: https://anthonynolan.atlassian.net/browse/ATL-279

## Test plan
- [ ] `terraform validate` on `terraform/core` (no local Terraform install available in this session to run it directly)
- [ ] Review Terraform plan output in CI/CD for DEV to confirm only `app_scale_limit` changes are proposed (no unintended resource replacement)
- [ ] After merge/deploy, confirm DEV's repeat-search, donor-management, match-prediction, and donor-import Function Apps show the expected scale-out cap in the Azure portal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1493)
<!-- Reviewable:end -->
