### PR TITLE
feat: ATL-276: replace FluentValidator in DonorInfoConverter with static function

### DIFF
--- a/Atlas.MatchingAlgorithm.Test/Validators/DonorUpdates/SearchableDonorInformationFastValidatorTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Validators/DonorUpdates/SearchableDonorInformationFastValidatorTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Atlas.Common.Public.Models.GeneticData;
+using Atlas.DonorImport.ExternalInterface.Models;
+using Atlas.MatchingAlgorithm.Validators.DonorInfo;
+using AutoFixture;
+using AwesomeAssertions;
+using FluentValidation;
+using NUnit.Framework;
+
+namespace Atlas.MatchingAlgorithm.Test.Validators.DonorUpdates;
+
+/// <summary>
+/// Pins <see cref="SearchableDonorInformationFastValidator"/> to <see cref="SearchableDonorInformationValidator"/>, which it replaces on
+/// the data refresh donor import hot path. Equivalence is asserted on everything observable: whether a <see cref="ValidationException"/>
+/// is thrown, its message, and the property name, message, error code and attempted value of every failure, in order.
+/// </summary>
+/// <remarks>
+/// The matrix is exhaustive by construction. Donor validation reads only the 12 HLA name fields; each locus is validated independently of
+/// the others; and each field's outcome depends only on which of four classes its value falls into (null, empty, whitespace-only, or
+/// populated). 6 loci x 4 x 4 = 96 cases therefore cover every reachable single-locus outcome, and the remaining tests cover donor id
+/// (which has a rule of its own) plus accumulation and ordering of failures across loci.
+/// </remarks>
+[TestFixture]
+public class SearchableDonorInformationFastValidatorTests
+{
+    public enum HlaName
+    {
+        Null,
+        Empty,
+        Whitespace,
+        Populated
+    }
+
+    private Fixture fixture;
+
+    [SetUp]
+    public void SetUp()
+    {
+        fixture = new Fixture();
+    }
+
+    private static IEnumerable<TestCaseData> EveryHlaNamePairAtEveryLocus() =>
+        from locus in Enum.GetValues<Locus>()
+        from position1 in Enum.GetValues<HlaName>()
+        from position2 in Enum.GetValues<HlaName>()
+        select new TestCaseData(locus, position1, position2);
+
+    [TestCaseSource(nameof(EveryHlaNamePairAtEveryLocus))]
+    public async Task ValidateAndThrow_ForEveryHlaNamePairAtEveryLocus_BehavesIdenticallyToFluentValidationValidator(
+        Locus locus,
+        HlaName position1,
+        HlaName position2)
+    {
+        var donor = FullyTypedDonor();
+        SetHlaAt(donor, locus, HlaNameOf(position1), HlaNameOf(position2));
+
+        await AssertBehavesIdenticallyToFluentValidationValidator(donor);
+    }
+
+    [TestCase(int.MinValue)]
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(int.MaxValue)]
+    public async Task ValidateAndThrow_ForAnyDonorId_BehavesIdenticallyToFluentValidationValidator(int donorId)
+    {
+        var donor = FullyTypedDonor();
+        donor.DonorId = donorId;
+
+        await AssertBehavesIdenticallyToFluentValidationValidator(donor);
+    }
+
+    [Test]
+    public async Task ValidateAndThrow_ForFullyTypedDonor_BehavesIdenticallyToFluentValidationValidator()
+    {
+        await AssertBehavesIdenticallyToFluentValidationValidator(FullyTypedDonor());
+    }
+
+    [Test]
+    public async Task ValidateAndThrow_ForDonorWithNoHlaAtAll_BehavesIdenticallyToFluentValidationValidator()
+    {
+        await AssertBehavesIdenticallyToFluentValidationValidator(new SearchableDonorInformation { DonorId = fixture.Create<int>() });
+    }
+
+    [Test]
+    public async Task ValidateAndThrow_ForDonorWithWhitespaceHlaAtEveryPosition_BehavesIdenticallyToFluentValidationValidator()
+    {
+        var donor = FullyTypedDonor();
+        foreach (var locus in Enum.GetValues<Locus>())
+        {
+            SetHlaAt(donor, locus, "  ", "  ");
+        }
+
+        await AssertBehavesIdenticallyToFluentValidationValidator(donor);
+    }
+
+    [Test]
+    public async Task ValidateAndThrow_ForDonorFailingAtEveryLocus_BehavesIdenticallyToFluentValidationValidator()
+    {
+        var donor = FullyTypedDonor();
+        SetHlaAt(donor, Locus.A, null, "  ");
+        SetHlaAt(donor, Locus.B, string.Empty, fixture.Create<string>());
+        SetHlaAt(donor, Locus.Drb1, "  ", null);
+        SetHlaAt(donor, Locus.C, fixture.Create<string>(), null);
+        SetHlaAt(donor, Locus.Dqb1, null, fixture.Create<string>());
+        SetHlaAt(donor, Locus.Dpb1, "  ", fixture.Create<string>());
+
+        await AssertBehavesIdenticallyToFluentValidationValidator(donor);
+    }
+
+    [Test]
+    public async Task ValidateAndThrow_ForDonorWithEveryOptionalLocusHalfTyped_BehavesIdenticallyToFluentValidationValidator()
+    {
+        var donor = FullyTypedDonor();
+        SetHlaAt(donor, Locus.C, fixture.Create<string>(), null);
+        SetHlaAt(donor, Locus.Dqb1, fixture.Create<string>(), null);
+        SetHlaAt(donor, Locus.Dpb1, fixture.Create<string>(), null);
+
+        await AssertBehavesIdenticallyToFluentValidationValidator(donor);
+    }
+
+    [Test]
+    public void ValidateAndThrow_ForValidDonor_AllocatesNothing()
+    {
+        const int warmUpIterations = 1_000;
+        const int measuredIterations = 10_000;
+
+        var donor = FullyTypedDonor();
+
+        for (var i = 0; i < warmUpIterations; i++)
+        {
+            SearchableDonorInformationFastValidator.ValidateAndThrow(donor);
+        }
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < measuredIterations; i++)
+        {
+            SearchableDonorInformationFastValidator.ValidateAndThrow(donor);
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        allocated.Should().Be(0, "the whole point of this validator is that the data refresh can run it once per donor for free");
+    }
+
+    private static async Task AssertBehavesIdenticallyToFluentValidationValidator(SearchableDonorInformation donor)
+    {
+        var expected = await FluentValidationOutcomeFor(donor);
+        var actual = FastValidatorOutcomeFor(donor);
+
+        actual.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
+    }
+
+    private static async Task<ValidationOutcome> FluentValidationOutcomeFor(SearchableDonorInformation donor)
+    {
+        try
+        {
+            await new SearchableDonorInformationValidator().ValidateAndThrowAsync(donor);
+            return ValidationOutcome.Valid;
+        }
+        catch (ValidationException e)
+        {
+            return ValidationOutcome.From(e);
+        }
+    }
+
+    private static ValidationOutcome FastValidatorOutcomeFor(SearchableDonorInformation donor)
+    {
+        try
+        {
+            SearchableDonorInformationFastValidator.ValidateAndThrow(donor);
+            return ValidationOutcome.Valid;
+        }
+        catch (ValidationException e)
+        {
+            return ValidationOutcome.From(e);
+        }
+    }
+
+    private SearchableDonorInformation FullyTypedDonor() =>
+        new()
+        {
+            DonorId = fixture.Create<int>(),
+            A_1 = fixture.Create<string>(),
+            A_2 = fixture.Create<string>(),
+            B_1 = fixture.Create<string>(),
+            B_2 = fixture.Create<string>(),
+            C_1 = fixture.Create<string>(),
+            C_2 = fixture.Create<string>(),
+            DQB1_1 = fixture.Create<string>(),
+            DQB1_2 = fixture.Create<string>(),
+            DPB1_1 = fixture.Create<string>(),
+            DPB1_2 = fixture.Create<string>(),
+            DRB1_1 = fixture.Create<string>(),
+            DRB1_2 = fixture.Create<string>()
+        };
+
+    private string HlaNameOf(HlaName hlaName) =>
+        hlaName switch
+        {
+            HlaName.Null => null,
+            HlaName.Empty => string.Empty,
+            HlaName.Whitespace => "  ",
+            HlaName.Populated => fixture.Create<string>(),
+            _ => throw new ArgumentOutOfRangeException(nameof(hlaName), hlaName, null)
+        };
+
+    private static void SetHlaAt(SearchableDonorInformation donor, Locus locus, string position1, string position2)
+    {
+        switch (locus)
+        {
+            case Locus.A:
+                donor.A_1 = position1;
+                donor.A_2 = position2;
+                break;
+            case Locus.B:
+                donor.B_1 = position1;
+                donor.B_2 = position2;
+                break;
+            case Locus.C:
+                donor.C_1 = position1;
+                donor.C_2 = position2;
+                break;
+            case Locus.Dpb1:
+                donor.DPB1_1 = position1;
+                donor.DPB1_2 = position2;
+                break;
+            case Locus.Dqb1:
+                donor.DQB1_1 = position1;
+                donor.DQB1_2 = position2;
+                break;
+            case Locus.Drb1:
+                donor.DRB1_1 = position1;
+                donor.DRB1_2 = position2;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(locus), locus, null);
+        }
+    }
+
+    private record ValidationOutcome(string ExceptionMessage, IReadOnlyList<Failure> Failures)
+    {
+        public static readonly ValidationOutcome Valid = new(null, Array.Empty<Failure>());
+
+        public static ValidationOutcome From(ValidationException exception) =>
+            new(
+                exception.Message,
+                exception.Errors.Select(e => new Failure(e.PropertyName, e.ErrorMessage, e.ErrorCode, e.AttemptedValue)).ToList());
+    }
+
+    private record Failure(string PropertyName, string ErrorMessage, string ErrorCode, object AttemptedValue);
+}

--- a/Atlas.MatchingAlgorithm/Services/DataRefresh/DonorImport/DonorInfoConverter.cs
+++ b/Atlas.MatchingAlgorithm/Services/DataRefresh/DonorImport/DonorInfoConverter.cs
@@ -31,7 +31,7 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh.DonorImport
         {
             return await ProcessBatchAsyncWithAnticipatedExceptions<ValidationException>(
                 donorInfos,
-                async info => await ConvertDonorInfo(info),
+                info => Task.FromResult(ConvertDonorInfo(info)),
                 info => new FailedDonorInfo(info)
                 {
                     AtlasDonorId = info.DonorId
@@ -39,9 +39,12 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh.DonorImport
                 failureEventName);
         }
 
-        private static async Task<DonorInfo> ConvertDonorInfo(SearchableDonorInformation donorInfo)
+        // Deliberately not SearchableDonorInformationValidator: identical outcome, but this runs once per donor in the registry, and
+        // building a FluentValidation rule tree per call dominated the cost of the entire conversion. See the remarks on
+        // SearchableDonorInformationFastValidator.
+        private static DonorInfo ConvertDonorInfo(SearchableDonorInformation donorInfo)
         {
-            await new SearchableDonorInformationValidator().ValidateAndThrowAsync(donorInfo);
+            SearchableDonorInformationFastValidator.ValidateAndThrow(donorInfo);
             return donorInfo.ToDonorInfo();
         }
     }

--- a/Atlas.MatchingAlgorithm/Validators/DonorInfo/SearchableDonorInformationFastValidator.cs
+++ b/Atlas.MatchingAlgorithm/Validators/DonorInfo/SearchableDonorInformationFastValidator.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.TransferModels;
+using Atlas.DonorImport.ExternalInterface.Models;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Atlas.MatchingAlgorithm.Validators.DonorInfo;
+
+/// <summary>
+/// Allocation-free equivalent of <see cref="SearchableDonorInformationValidator"/>, for the data refresh donor import hot path
+/// (<c>DonorInfoConverter</c>), which validates every donor in the registry - tens of millions of times per refresh.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constructing a <see cref="SearchableDonorInformationValidator"/> builds 8 validator objects and 20 <c>RuleFor</c> expression chains
+/// in order to run 12 non-empty string checks, and was measured at ~64 microseconds and ~55 KB per donor (ATL-276). This class runs the
+/// same 12 checks directly, in single-digit nanoseconds and with zero allocations.
+/// </para>
+/// <para>
+/// This is an addition, not a replacement. <see cref="SearchableDonorInformationValidator"/> remains in use by
+/// <see cref="SearchableDonorUpdateValidator"/>, and remains the definition of "a valid searchable donor". The two are held in step by
+/// <c>SearchableDonorInformationFastValidatorTests</c>, which asserts identical outcomes - down to exception message, property names,
+/// error codes and ordering - across an exhaustive per-locus matrix. If a rule is added to
+/// <see cref="SearchableDonorInformationValidator"/>, or to the <c>PhenotypeHlaNamesValidator</c> family in Atlas.Common that it
+/// delegates to, that test will fail: mirror the new rule here.
+/// </para>
+/// </remarks>
+internal static class SearchableDonorInformationFastValidator
+{
+    /// <summary>
+    /// FluentValidation's default message for both <c>NotNull()</c> and <c>NotEmpty()</c>. <c>{PropertyName}</c> is substituted with the
+    /// property's display name, which for "Position1"/"Position2" is the property name unchanged.
+    /// </summary>
+    private const string NotEmptyMessageFormat = "'{0}' must not be empty.";
+
+    private const string NotEmptyErrorCode = "NotEmptyValidator";
+
+    // Reported property names are those of the PhenotypeInfoTransfer that SearchableDonorInformationValidator projects each donor into
+    // before validating it, not those of SearchableDonorInformation itself - hence "Drb1.Position1" rather than "DRB1_1".
+    private const string Position1 = nameof(LocusInfoTransfer<string>.Position1);
+    private const string Position2 = nameof(LocusInfoTransfer<string>.Position2);
+    private const string LocusA = nameof(PhenotypeInfoTransfer<string>.A);
+    private const string LocusB = nameof(PhenotypeInfoTransfer<string>.B);
+    private const string LocusC = nameof(PhenotypeInfoTransfer<string>.C);
+    private const string LocusDpb1 = nameof(PhenotypeInfoTransfer<string>.Dpb1);
+    private const string LocusDqb1 = nameof(PhenotypeInfoTransfer<string>.Dqb1);
+    private const string LocusDrb1 = nameof(PhenotypeInfoTransfer<string>.Drb1);
+
+    /// <summary>
+    /// Throws the same <see cref="ValidationException"/> that
+    /// <c>new SearchableDonorInformationValidator().ValidateAndThrowAsync(donorInfo)</c> would throw.
+    /// </summary>
+    public static void ValidateAndThrow(SearchableDonorInformation donorInfo)
+    {
+        if (IsValid(donorInfo))
+        {
+            return;
+        }
+
+        throw BuildValidationException(donorInfo);
+    }
+
+    /// <summary>
+    /// Mirrors <c>PhenotypeHlaNamesValidator</c>. The only rule of
+    /// <see cref="SearchableDonorInformationValidator"/> not represented here is <c>RuleFor(x => x.DonorId).NotNull()</c>, on a
+    /// non-nullable <see cref="int"/>: it can never fail.
+    /// </summary>
+    private static bool IsValid(SearchableDonorInformation donorInfo) =>
+        IsRequiredLocusValid(donorInfo.A_1, donorInfo.A_2) &&
+        IsRequiredLocusValid(donorInfo.B_1, donorInfo.B_2) &&
+        IsRequiredLocusValid(donorInfo.DRB1_1, donorInfo.DRB1_2) &&
+        IsOptionalLocusValid(donorInfo.C_1, donorInfo.C_2) &&
+        IsOptionalLocusValid(donorInfo.DQB1_1, donorInfo.DQB1_2) &&
+        IsOptionalLocusValid(donorInfo.DPB1_1, donorInfo.DPB1_2);
+
+    /// <summary>Mirrors <c>RequiredLocusHlaNamesValidator</c>: both positions must always be populated.</summary>
+    private static bool IsRequiredLocusValid(string position1, string position2) =>
+        !FailsNotEmpty(position1) && !FailsNotEmpty(position2);
+
+    /// <summary>Mirrors <c>OptionalLocusHlaNamesValidator</c>: a locus may be untyped, but not half-typed.</summary>
+    private static bool IsOptionalLocusValid(string position1, string position2) =>
+        !OptionalPositionFailsNotEmpty(position1, position2) && !OptionalPositionFailsNotEmpty(position2, position1);
+
+    /// <summary>
+    /// An optional position is only required when the other position at that locus is typed.
+    /// </summary>
+    private static bool OptionalPositionFailsNotEmpty(string position, string otherPosition) =>
+        !IsUntyped(otherPosition) && FailsNotEmpty(position);
+
+    /// <summary>FluentValidation's <c>NotEmpty()</c> rejects null, empty and whitespace-only strings.</summary>
+    private static bool FailsNotEmpty(string hlaName) => string.IsNullOrWhiteSpace(hlaName);
+
+    /// <summary>
+    /// The <c>When()</c> guards in <c>OptionalLocusHlaNamesValidator</c> use Atlas.Common's <c>IsNullOrEmpty()</c>, which - unlike
+    /// <c>NotEmpty()</c> - counts a whitespace-only string as populated. The asymmetry is deliberately preserved: whitespace at one
+    /// position makes the other position required, and then fails <c>NotEmpty()</c> on its own account.
+    /// </summary>
+    private static bool IsUntyped(string hlaName) => string.IsNullOrEmpty(hlaName);
+
+    /// <remarks>
+    /// Kept out of <see cref="ValidateAndThrow"/> so that the success path stays small enough to inline, and allocates nothing.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ValidationException BuildValidationException(SearchableDonorInformation donorInfo)
+    {
+        // Locus order, and position order within a locus, follow the RuleFor declaration order in PhenotypeHlaNamesValidator, so that
+        // logged validation errors read exactly as they did when FluentValidation produced them.
+        var failures = new List<ValidationFailure>();
+
+        AddRequiredLocusFailures(failures, LocusA, donorInfo.A_1, donorInfo.A_2);
+        AddRequiredLocusFailures(failures, LocusB, donorInfo.B_1, donorInfo.B_2);
+        AddRequiredLocusFailures(failures, LocusDrb1, donorInfo.DRB1_1, donorInfo.DRB1_2);
+        AddOptionalLocusFailures(failures, LocusC, donorInfo.C_1, donorInfo.C_2);
+        AddOptionalLocusFailures(failures, LocusDqb1, donorInfo.DQB1_1, donorInfo.DQB1_2);
+        AddOptionalLocusFailures(failures, LocusDpb1, donorInfo.DPB1_1, donorInfo.DPB1_2);
+
+        return new ValidationException(failures);
+    }
+
+    private static void AddRequiredLocusFailures(
+        ICollection<ValidationFailure> failures,
+        string locusName,
+        string position1,
+        string position2)
+    {
+        if (FailsNotEmpty(position1))
+        {
+            failures.Add(NotEmptyFailure(locusName, Position1, position1));
+        }
+
+        if (FailsNotEmpty(position2))
+        {
+            failures.Add(NotEmptyFailure(locusName, Position2, position2));
+        }
+    }
+
+    private static void AddOptionalLocusFailures(
+        ICollection<ValidationFailure> failures,
+        string locusName,
+        string position1,
+        string position2)
+    {
+        if (OptionalPositionFailsNotEmpty(position1, position2))
+        {
+            failures.Add(NotEmptyFailure(locusName, Position1, position1));
+        }
+
+        if (OptionalPositionFailsNotEmpty(position2, position1))
+        {
+            failures.Add(NotEmptyFailure(locusName, Position2, position2));
+        }
+    }
+
+    private static ValidationFailure NotEmptyFailure(string locusName, string positionName, string attemptedValue) =>
+        new($"{locusName}.{positionName}", string.Format(NotEmptyMessageFormat, positionName), attemptedValue)
+        {
+            ErrorCode = NotEmptyErrorCode
+        };
+}

--- a/Atlas.MatchingAlgorithm/Validators/DonorInfo/SearchableDonorInformationValidator.cs
+++ b/Atlas.MatchingAlgorithm/Validators/DonorInfo/SearchableDonorInformationValidator.cs
@@ -5,6 +5,11 @@ using FluentValidation;
 
 namespace Atlas.MatchingAlgorithm.Validators.DonorInfo
 {
+    /// <remarks>
+    /// The data refresh donor import runs these rules tens of millions of times per refresh, and does so via
+    /// <see cref="SearchableDonorInformationFastValidator"/> instead, for cost reasons. Any rule changed or added here must be mirrored
+    /// there; <c>SearchableDonorInformationFastValidatorTests</c> enforces that the two stay equivalent.
+    /// </remarks>
     public class SearchableDonorInformationValidator : AbstractValidator<SearchableDonorInformation>
     {
         public SearchableDonorInformationValidator()


### PR DESCRIPTION
As per ticket description, the fluent validator was replaced by a static function invocation - this will avoid additional allocations on actual validation calls (even when FluentValidator is hoisted into a static variable, it still allocates on each validation call), expose validation logic and allow compiler to optimise the code if necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1495)
<!-- Reviewable:end -->
