### PR TITLE
fix: ATL-291: raise CommandTimeout for MatchPredictionContext

### DIFF
--- a/Atlas.Functions/Startup.cs
+++ b/Atlas.Functions/Startup.cs
@@ -175,7 +175,9 @@ namespace Atlas.Functions
             {
                 options.UseSqlServer(
                     ConnectionStringReader("MatchPrediction:Sql")(sp),
-                    sqlOptions => sqlOptions.EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), null));
+                    sqlOptions => sqlOptions
+                        .EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), null)
+                        .CommandTimeout((int)TimeSpan.FromMinutes(10).TotalSeconds));
             });
 
             services.AddScoped<IParallelMatchPredictionRepository, ParallelMatchPredictionRepository>();


### PR DESCRIPTION
## Summary
- `CleanupOldParallelMatchPredictionBatches` was timing out because the production `MatchPredictionContext` never overrode the SqlClient/EF Core default 30s `CommandTimeout`, while the same DELETE routinely needs longer as the batch-cleanup backlog grows.
- Raise `CommandTimeout` to 10 minutes on `MatchPredictionContext` (`Atlas.Functions/Startup.cs`, `RegisterMatchPredictionDatabase`), matching the pattern already used by `Atlas.MatchPrediction.Test.Verification.Data` and `Atlas.MatchPrediction.Test.Validation.Data`'s `ContextFactory`s.

See ATL-291 for the full root-cause writeup and the fix proposal this implements.

## Test plan
- [x] `dotnet build Atlas.Functions/Atlas.Functions.csproj --configuration Release` — 0 errors
- [ ] Deploy and confirm `CleanupOldParallelMatchPredictionBatches` completes and clears the backlog (watch App Insights execution duration + the "batch cleanup deleted {Count}" log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1502)
<!-- Reviewable:end -->
