### PR TITLE
feature: ATL-237: Reduce Transaction batch size for data table inserts

### DIFF
--- a/Atlas.Common/AzureStorage/TableStorage/AzureCosmosLibraryTableExtensions.cs
+++ b/Atlas.Common/AzureStorage/TableStorage/AzureCosmosLibraryTableExtensions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using Azure.Core;
 using Azure.Data.Tables;
 using Dasync.Collections;
 using MoreLinq;
@@ -26,7 +24,7 @@ namespace Atlas.Common.AzureStorage.TableStorage
 
 
         //ExecuteBatchAsync has a limit on how many operations can be put in a single batch. :(
-        private const int BatchSize = 100;
+        private const int BatchSize = 50;
 
         /*
          * Note that the internet recommends the following settings for optimal AzureTableStorage Insert performance.
@@ -46,8 +44,8 @@ namespace Atlas.Common.AzureStorage.TableStorage
             // List<List<List<TEntities>>> 
             // This construct is:
             // * A List of Partitions, each containing
-            //   * List of 100-entity-batches within that partition, each containing
-            //     * List of (100) Entities within that batch (all of which have a single PartitionKey)
+            //   * List of 50-entity-batches within that partition, each containing
+            //     * List of (50) Entities within that batch (all of which have a single PartitionKey)
             //
             // We start from this construct as it allows easy refactors of how we divvy these inserts up, in the future.
             List<List<List<TEntity>>> entitiesPartitionedWithSubBatches = entities


### PR DESCRIPTION
Required to prevent this error
Azure.RequestFailedException: The request body is too large and exceeds the maximum permissible limit.

Tested locally with 60, error still occurs, with 50, data tables were created in UAT

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1504)
<!-- Reviewable:end -->
