### PR TITLE
feature: ATL-313: Tag GitHub commit on successful deployment to LIVE / WMDA LIVE

### DIFF
--- a/.github/workflows/delete_rc_on_release.yml
+++ b/.github/workflows/delete_rc_on_release.yml
@@ -1,5 +1,5 @@
 # This workflow will:
-# * When a released tag is pushed:
+# * When a version is tagged as released to WMDA LIVE (the last environment in the release cadence):
 # * Parse the major/minor version of the tag
 # * Delete any corresponding rc/* branch from origin
 
@@ -8,7 +8,7 @@ name: Delete Deployed Release Candidate Branch
 on:
   push:
     tags:
-      - 'released/**'
+      - 'released/wmda/**'
 
 jobs:
   delete-rc-branch:

--- a/README_Contribution_Versioning.md
+++ b/README_Contribution_Versioning.md
@@ -59,6 +59,7 @@ This sign-off process should involve ensuring:
 
 ### Other Tags
 * The `unverified/x.y.z` tag will be used occasionally to manage the release of versions to non-production environments.
+* The `released/an/x.y.z` and `released/wmda/x.y.z` tags are applied automatically by the release pipeline when version `x.y.z` is successfully deployed to Anthony Nolan's LIVE and WMDA's LIVE environments respectively. Each is created once per version and never moved, so these tags are only meaningful as long as a version number is never redeployed with different code (i.e. version bumps happen before every deploy, as semver already requires).
 
 ## Contributing
 

--- a/terraform/core/function.tf
+++ b/terraform/core/function.tf
@@ -187,8 +187,8 @@ resource "azurerm_windows_function_app" "atlas_public_api_function" {
   app_settings = {
     "ApplicationInsights:LogLevel" = var.APPLICATION_INSIGHTS_LOG_LEVEL
 
-    "AutoMapper:LicenseKey" = var.AUTOMAPPER_LICENSE_KEY
-    "AtlasFunction:Search:DefaultParallelMatchPrediction" = var.DEFAULT_PARALLEL_MATCH_PREDICTION
+    "AutoMapper:LicenseKey"                                         = var.AUTOMAPPER_LICENSE_KEY
+    "AtlasFunction:Search:DefaultParallelMatchPrediction"           = var.DEFAULT_PARALLEL_MATCH_PREDICTION
     "AtlasFunction:Search:ParallelMatchPredictionRequestPercentage" = var.PARALLEL_MATCH_PREDICTION_REQUEST_PERCENTAGE
 
     "MatchingAlgorithmFunction:BaseUrl" = module.matching_algorithm.function_app.base_url


### PR DESCRIPTION
## Summary
- Split the release-tag convention into `released/an/x.y.z` (LIVE) and `released/wmda/x.y.z` (WMDA LIVE) on the Azure DevOps release definition (Release-1) — cloned the existing `File content to variable` + `GitHub release (edit)` task block from LIVE onto WMDA LIVE, which previously had no tagging at all.
- Gated `rc/*` branch deletion on `released/wmda/**` only (not `released/an/**`), since AN LIVE and WMDA LIVE deploys of the same version can be weeks apart and the branch should only be deleted once, after the release has fully rolled out to both environments.
- Documented the new tag convention in `README_Contribution_Versioning.md`.

## Test plan
- [ ] Confirm on the next LIVE deploy: `released/an/<version>` tag appears at the correct commit, `rc/<major.minor>` branch is *not* deleted yet.
- [ ] Confirm on the next WMDA LIVE deploy of that same version: `released/wmda/<version>` tag appears at the correct commit, and the `rc/<major.minor>` branch is deleted.

Jira: ATL-313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1510)
<!-- Reviewable:end -->
