### PR TITLE
feature: ATL-233: stop the exception path for an expected HLA lookup failure

### DIFF
--- a/Atlas.HlaMetadataDictionary.Test/IntegrationTests/Tests/LookupFailurePropagationTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/IntegrationTests/Tests/LookupFailurePropagationTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Atlas.Common.ApplicationInsights;
+using Atlas.Common.GeneticData.Hla.Models;
+using Atlas.Common.Public.Models.GeneticData;
+using Atlas.Common.Utils.Extensions;
+using Atlas.HlaMetadataDictionary.ExternalInterface;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Models;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata;
+using Atlas.HlaMetadataDictionary.InternalModels.Metadata;
+using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
+using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
+using Atlas.HlaMetadataDictionary.Services.DataRetrieval;
+using Atlas.HlaMetadataDictionary.Test.IntegrationTests.DependencyInjection;
+using Atlas.HlaMetadataDictionary.Test.IntegrationTests.TestHelpers.FileBackedStorageStubs;
+using Atlas.MultipleAlleleCodeDictionary.Settings;
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Atlas.HlaMetadataDictionary.Test.IntegrationTests.Tests
+{
+    /// <summary>
+    /// Does a failure below the dictionary reach the top of it as the failure it was?
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Nothing here is a mock of a class under test. The whole graph is real and wired by the real DI registration -
+    /// <c>HlaScoringMetadataService</c>, <c>SearchRelatedMetadataServiceBase</c>, <c>AlleleNamesLookupBase</c>,
+    /// <c>AlleleNamesMetadataService</c>, <c>MetadataServiceBase</c>, the caching, the external interface - and only
+    /// the storage layer underneath it is a stub, as it is for every test in this folder. One repository is given the
+    /// ability to fault, and the question asked at the top is what came out.
+    /// </para>
+    /// <para>
+    /// Which is a question the unit tests structurally cannot ask. They exercise leaf services, whose
+    /// <c>PerformLookup</c> reaches a repository and nothing else. The bug this fixture pins lived in the gap between
+    /// two <c>MetadataServiceBase</c> instances: the scoring lookup for an allele it does not hold falls through to
+    /// <see cref="IAlleleNamesMetadataService"/>, whose own <c>GetMetadata</c> used to re-label a storage failure as
+    /// an <see cref="HlaMetadataDictionaryException"/> on the way back up. The outer lookup then read that as "this
+    /// name is not in the data", cached it for the lifetime of the persistent cache, and every caller above -
+    /// matching skipping the donor, Match Prediction predicting from an incomplete expansion - believed it.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal class LookupFailurePropagationTests
+    {
+        private const Locus DefaultLocus = Locus.A;
+        private const string HlaVersion = FileBackedHlaMetadataRepositoryBaseReader.OlderTestHlaVersion;
+
+        /// <summary>
+        /// Well formed, and deliberately not in the test data, so that the scoring lookup falls through to the allele
+        /// NAMES lookup - the nested <c>MetadataServiceBase</c> call this fixture exists to cover.
+        /// </summary>
+        private const string AlleleNotInTheDictionary = "9999:9999";
+
+        private FaultInjectingAlleleNamesRepository alleleNamesRepository;
+        private IHlaScoringMetadataService scoringMetadataService;
+        private IHlaMetadataDictionary hlaMetadataDictionary;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // A provider per test, not the shared one: the persistent cache is a singleton, and half of what these
+            // tests assert is what does and does not end up in it.
+            var services = new ServiceCollection();
+            services.RegisterFileBasedHlaMetadataDictionaryForTesting(
+                _ => new ApplicationInsightsSettings { LogLevel = "Info" },
+                DependencyInjectionUtils.OptionsReaderFor<MacDictionarySettings>()
+            );
+
+            alleleNamesRepository = new FaultInjectingAlleleNamesRepository();
+            services.AddSingleton<IAlleleNamesMetadataRepository>(alleleNamesRepository);
+
+            var provider = services.BuildServiceProvider();
+            scoringMetadataService = provider.GetRequiredService<IHlaScoringMetadataService>();
+            hlaMetadataDictionary = provider.GetRequiredService<IHlaMetadataDictionaryFactory>().BuildDictionary(HlaVersion);
+        }
+
+        [Test]
+        public async Task GetHlaMetadata_WhenANestedLookupFaults_PropagatesTheFaultAsItself()
+        {
+            alleleNamesRepository.Fault = new TimeoutException("storage is having a moment");
+
+            // Not an HlaMetadataDictionaryException. That is the entire point: a caller has to be able to tell a
+            // storage account having a bad minute from an HLA name that does not exist.
+            await scoringMetadataService.Invoking(s => s.GetHlaMetadata(DefaultLocus, AlleleNotInTheDictionary, HlaVersion))
+                .Should().ThrowAsync<TimeoutException>();
+        }
+
+        [Test]
+        public async Task TryConvertHla_WhenANestedLookupFaults_PropagatesInsteadOfReportingNotFound()
+        {
+            alleleNamesRepository.Fault = new TimeoutException("storage is having a moment");
+
+            // The non-throwing route, which Match Prediction uses and which has no catch of its own. Reporting this
+            // as `(false, null)` is what would let a prediction run on an incomplete expansion with nothing logged
+            // as an error.
+            await hlaMetadataDictionary
+                .Invoking(d => d.TryConvertHla(DefaultLocus, AlleleNotInTheDictionary, TargetHlaCategory.PGroup))
+                .Should().ThrowAsync<TimeoutException>();
+        }
+
+        [Test]
+        public async Task GetHlaMetadata_WhenANestedLookupFaults_DoesNotCacheTheFault()
+        {
+            alleleNamesRepository.Fault = new TimeoutException("storage is having a moment");
+
+            await scoringMetadataService.Invoking(s => s.GetHlaMetadata(DefaultLocus, AlleleNotInTheDictionary, HlaVersion))
+                .Should().ThrowAsync<TimeoutException>();
+
+            // A transient fault must not be remembered as an answer. While it was re-labelled as a missing name it
+            // was cached like one, so a blip lasted as long as the persistent cache did - a day, by default.
+            alleleNamesRepository.Fault = null;
+            var callsAfterTheFault = alleleNamesRepository.CallCount;
+
+            await scoringMetadataService.Invoking(s => s.GetHlaMetadata(DefaultLocus, AlleleNotInTheDictionary, HlaVersion))
+                .Should().ThrowAsync<HlaMetadataDictionaryException>();
+
+            alleleNamesRepository.CallCount.Should().BeGreaterThan(callsAfterTheFault);
+        }
+
+        [Test]
+        public async Task GetHlaMetadata_WhenTheNameIsNotInTheData_StillReportsAMissingName()
+        {
+            // The control, and the reason narrowing the catch is safe rather than merely correct: a genuine miss is
+            // untouched. DonorHlaExpander, SearchRunner and RepeatSearchRunner all treat this exception as an
+            // expected error, and all three still get it.
+            await scoringMetadataService.Invoking(s => s.GetHlaMetadata(DefaultLocus, AlleleNotInTheDictionary, HlaVersion))
+                .Should().ThrowAsync<HlaMetadataDictionaryException>();
+        }
+
+        [Test]
+        public async Task TryConvertHla_WhenTheNameIsNotInTheData_ReportsNotFound()
+        {
+            var (wasFound, hla) = await hlaMetadataDictionary.TryConvertHla(
+                DefaultLocus, AlleleNotInTheDictionary, TargetHlaCategory.PGroup
+            );
+
+            wasFound.Should().BeFalse();
+            hla.Should().BeNull();
+        }
+
+        [Test]
+        public async Task GetHlaMetadata_WhenTheNameIsUnparseable_ReportsAMissingNameRatherThanFaulting()
+        {
+            // The categoriser reports a name it cannot parse by throwing AtlasHttpException, which is not a lookup
+            // failure in this dictionary's vocabulary. One malformed donor record used to be re-labelled along with
+            // everything else; now that only genuine misses are, it has to say so itself - or a single bad record
+            // would fail an entire data refresh batch.
+            await scoringMetadataService.Invoking(s => s.GetHlaMetadata(DefaultLocus, "not-an-hla-name", HlaVersion))
+                .Should().ThrowAsync<HlaMetadataDictionaryException>();
+        }
+
+        /// <summary>
+        /// The real file-backed repository, with a switch on it. The only stubbed thing in the graph, and it is
+        /// stubbed at the layer every test in this folder already stubs: storage.
+        /// </summary>
+        private class FaultInjectingAlleleNamesRepository : IAlleleNamesMetadataRepository
+        {
+            private readonly FileBackedAlleleNamesMetadataRepository inner = new();
+
+            public Exception Fault { get; set; }
+
+            public int CallCount { get; private set; }
+
+            public Task<IAlleleNameMetadata> GetAlleleNameIfExists(Locus locus, string lookupName, string hlaNomenclatureVersion)
+            {
+                CallCount++;
+
+                return Fault != null
+                    ? throw Fault
+                    : inner.GetAlleleNameIfExists(locus, lookupName, hlaNomenclatureVersion);
+            }
+
+            public Task LoadDataIntoMemory(string hlaNomenclatureVersion) => inner.LoadDataIntoMemory(hlaNomenclatureVersion);
+
+            public Task RecreateHlaMetadataTable(IEnumerable<ISerialisableHlaMetadata> metadata, string hlaNomenclatureVersion) =>
+                inner.RecreateHlaMetadataTable(metadata, hlaNomenclatureVersion);
+
+            public Task<HlaMetadataTableRow> GetHlaMetadataRowIfExists(
+                Locus locus,
+                string lookupName,
+                TypingMethod typingMethod,
+                string hlaNomenclatureVersion) =>
+                inner.GetHlaMetadataRowIfExists(locus, lookupName, typingMethod, hlaNomenclatureVersion);
+        }
+    }
+}

--- a/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/DataRetrieval/MetadataServices/MetadataServiceBaseTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/DataRetrieval/MetadataServices/MetadataServiceBaseTests.cs
@@ -7,6 +7,7 @@ using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.Common.Public.Models.GeneticData;
 using Atlas.Common.Test.SharedTestHelpers.Builders;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.Metadata;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 using Atlas.HlaMetadataDictionary.Services.DataRetrieval;
@@ -103,7 +104,6 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataRetrieval.Meta
 
             await repository.Received(1).GetAlleleNameIfExists(locus, lookupName, versionOne);
             await repository.Received(1).GetAlleleNameIfExists(locus, lookupName, versionTwo);
-
         }
 
         // ---- A name with no data is remembered; an infrastructure fault is not ------------------------
@@ -157,15 +157,38 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataRetrieval.Meta
             repository.GetAlleleNameIfExists(locus, lookupName, version).Returns<IAlleleNameMetadata>(_ =>
                 faulted
                     ? throw new TimeoutException("storage is having a moment")
-                    : new AlleleNameMetadata("A*", default, default));
+                    : new AlleleNameMetadata("A*", default, default)
+            );
 
-            await ShouldFailLookup(locus, lookupName, version);
+            // As ITSELF, not as an HlaMetadataDictionaryException. GetMetadata used to re-label every exception, so a
+            // caller could not tell a blip from a name that is not in the data: the matching algorithm skipped a
+            // donor the storage account had merely hidden, and it looked exactly like invalid HLA in the logs.
+            await metadataService.Invoking(s => s.GetCurrentAlleleNames(locus, lookupName, version))
+                .Should().ThrowAsync<TimeoutException>();
 
             faulted = false;
             var recovered = await metadataService.GetCurrentAlleleNames(locus, lookupName, version);
 
             recovered.Should().NotBeNull();
             await repository.Received(2).GetAlleleNameIfExists(locus, lookupName, version);
+        }
+
+        [Test]
+        public async Task GetMetadata_WhenTheNameIsNotInTheData_ReportsItAsAMissingName()
+        {
+            const Locus locus = Locus.A;
+            const string lookupName = "hla-that-does-not-exist";
+            const string version = "version";
+
+            repository.GetAlleleNameIfExists(locus, lookupName, version).ReturnsNull();
+
+            // The other half of the boundary, and the reason narrowing the catch is safe: a genuine miss still
+            // arrives as the exception DonorHlaExpander, SearchRunner and RepeatSearchRunner treat as an expected
+            // error. Only what is NOT a miss changed.
+            var exception = await ShouldFailLookup(locus, lookupName, version);
+
+            exception.Should().BeOfType<HlaMetadataDictionaryException>();
+            exception.InnerException.Should().BeOfType<InvalidHlaException>();
         }
 
         // ---- The same lookup, with "no data for this name" as a value rather than an exception ---
@@ -276,7 +299,8 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataRetrieval.Meta
                 .Returns<IMolecularTypingToPGroupMetadata>(_ =>
                     faulted
                         ? throw new TimeoutException("storage is having a moment")
-                        : new MolecularTypingToPGroupMetadata(locus, gGroup, expectedPGroup));
+                        : new MolecularTypingToPGroupMetadata(locus, gGroup, expectedPGroup)
+                );
 
             await gGroupToPGroupService.Invoking(s => s.TryConvertGGroupToPGroup(locus, gGroup, version))
                 .Should().ThrowAsync<TimeoutException>();

--- a/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/DataRetrieval/MetadataServices/MetadataServiceBaseTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/DataRetrieval/MetadataServices/MetadataServiceBaseTests.cs
@@ -1,15 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Atlas.Common.Caching;
 using Atlas.Common.GeneticData;
 using Atlas.Common.GeneticData.Hla.Models;
 using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.Common.Public.Models.GeneticData;
 using Atlas.Common.Test.SharedTestHelpers.Builders;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.Metadata;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 using Atlas.HlaMetadataDictionary.Services.DataRetrieval;
+using AutoFixture;
+using AwesomeAssertions;
 using LazyCache;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NUnit.Framework;
 
 namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataRetrieval.MetadataServices
@@ -25,17 +30,26 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataRetrieval.Meta
         private IHlaCategorisationService hlaCategorisationService;
         private IAppCache cache;
 
+        private GGroupToPGroupMetadataService gGroupToPGroupService;
+
+        private IGGroupToPGroupMetadataRepository gGroupToPGroupRepository;
+        private Fixture fixture;
+
         [SetUp]
         public void SetUp()
         {
+            fixture = new Fixture();
+
             repository = Substitute.For<IAlleleNamesMetadataRepository>();
             hlaCategorisationService = Substitute.For<IHlaCategorisationService>();
+            gGroupToPGroupRepository = Substitute.For<IGGroupToPGroupMetadataRepository>();
 
             cache = AppCacheBuilder.NewDefaultCache();
             var cacheProvider = Substitute.For<IPersistentCacheProvider>();
             cacheProvider.Cache.Returns(cache);
 
             metadataService = new AlleleNamesMetadataService(repository, hlaCategorisationService, cacheProvider);
+            gGroupToPGroupService = new GGroupToPGroupMetadataService(gGroupToPGroupRepository, cacheProvider);
 
             repository.GetAlleleNameIfExists(default, default, default)
                 .ReturnsForAnyArgs(new AlleleNameMetadata("A*", default, default));
@@ -90,6 +104,203 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.DataRetrieval.Meta
             await repository.Received(1).GetAlleleNameIfExists(locus, lookupName, versionOne);
             await repository.Received(1).GetAlleleNameIfExists(locus, lookupName, versionTwo);
 
+        }
+
+        // ---- A name with no data is remembered; an infrastructure fault is not ------------------------
+
+        [Test]
+        public async Task GetMetadata_MultipleLookupsOfANameWithNoData_OnlyFetchesFromRepositoryOnce()
+        {
+            const Locus locus = Locus.A;
+            const string lookupName = "hla-that-does-not-exist";
+            const string version = "version";
+
+            // The repository is an *IfExists method and answers null; PerformLookup turns that into InvalidHlaException.
+            repository.GetAlleleNameIfExists(locus, lookupName, version).ReturnsNull();
+
+            for (var i = 0; i < 5; i++)
+            {
+                await ShouldFailLookup(locus, lookupName, version);
+            }
+
+            await repository.Received(1).GetAlleleNameIfExists(locus, lookupName, version);
+        }
+
+        [Test]
+        public async Task GetMetadata_WhenTheNameHasNoData_StillReportsTheFailureOnEveryCall()
+        {
+            const Locus locus = Locus.A;
+            const string lookupName = "hla-that-does-not-exist";
+            const string version = "version";
+
+            repository.GetAlleleNameIfExists(locus, lookupName, version).ReturnsNull();
+
+            // Caching the outcome must not turn a failed lookup into a successful one: every caller still sees the
+            // same exception, because DonorHlaExpander and SearchRunner use it as their expected-error pathway.
+            var first = await ShouldFailLookup(locus, lookupName, version);
+            var second = await ShouldFailLookup(locus, lookupName, version);
+
+            first.Message.Should().Be(second.Message);
+        }
+
+        [Test]
+        public async Task GetMetadata_WhenTheRepositoryFaults_DoesNotCacheTheFault()
+        {
+            const Locus locus = Locus.A;
+            const string lookupName = "hla";
+            const string version = "version";
+
+            var faulted = true;
+
+            // A transient infrastructure fault - a failed storage request, a timeout - rather than a missing name.
+            // Caching it for the cache lifetime would turn a blip into an outage, so the entry must not be kept.
+            repository.GetAlleleNameIfExists(locus, lookupName, version).Returns<IAlleleNameMetadata>(_ =>
+                faulted
+                    ? throw new TimeoutException("storage is having a moment")
+                    : new AlleleNameMetadata("A*", default, default));
+
+            await ShouldFailLookup(locus, lookupName, version);
+
+            faulted = false;
+            var recovered = await metadataService.GetCurrentAlleleNames(locus, lookupName, version);
+
+            recovered.Should().NotBeNull();
+            await repository.Received(2).GetAlleleNameIfExists(locus, lookupName, version);
+        }
+
+        // ---- The same lookup, with "no data for this name" as a value rather than an exception ---
+
+        [Test]
+        public async Task TryGetMetadata_WhenTheNameHasNoData_ReportsNotFoundWithoutThrowing()
+        {
+            var locus = fixture.Create<Locus>();
+            var gGroup = fixture.Create<string>();
+            var version = fixture.Create<string>();
+
+            gGroupToPGroupRepository.GetPGroupByGGroupIfExists(locus, gGroup, version).ReturnsNull();
+
+            var (wasFound, pGroup) = await gGroupToPGroupService.TryConvertGGroupToPGroup(locus, gGroup, version);
+
+            wasFound.Should().BeFalse();
+            pGroup.Should().BeNull();
+        }
+
+        [Test]
+        public async Task TryGetMetadata_WhenTheNameIsInTheData_ReportsTheValue()
+        {
+            var locus = fixture.Create<Locus>();
+            var gGroup = fixture.Create<string>();
+            var version = fixture.Create<string>();
+            var expectedPGroup = fixture.Create<string>();
+
+            gGroupToPGroupRepository.GetPGroupByGGroupIfExists(locus, gGroup, version)
+                .Returns(new MolecularTypingToPGroupMetadata(locus, gGroup, expectedPGroup));
+
+            var (wasFound, pGroup) = await gGroupToPGroupService.TryConvertGGroupToPGroup(locus, gGroup, version);
+
+            wasFound.Should().BeTrue();
+            pGroup.Should().Be(expectedPGroup);
+        }
+
+        [Test]
+        public async Task TryGetMetadata_WhenTheNameIsInTheDataButHasNoPGroup_ReportsFoundWithANullValue()
+        {
+            var locus = fixture.Create<Locus>();
+            var gGroup = fixture.Create<string>();
+            var version = fixture.Create<string>();
+
+            // The outcome a bare value cannot express, and the reason the tuple carries a bool at all: a G group of
+            // null-expressing alleles IS in the data and has no P group. Reading that as "not found" would log a
+            // conversion failure and drop the haplotype, instead of pooling it under a null P group.
+            gGroupToPGroupRepository.GetPGroupByGGroupIfExists(locus, gGroup, version)
+                .Returns(new MolecularTypingToPGroupMetadata(locus, gGroup, null));
+
+            var (wasFound, pGroup) = await gGroupToPGroupService.TryConvertGGroupToPGroup(locus, gGroup, version);
+
+            wasFound.Should().BeTrue();
+            pGroup.Should().BeNull();
+        }
+
+        [Test]
+        public async Task TryGetMetadata_MultipleLookupsOfANameWithNoData_OnlyFetchesFromRepositoryOnce()
+        {
+            var locus = fixture.Create<Locus>();
+            var gGroup = fixture.Create<string>();
+            var version = fixture.Create<string>();
+
+            gGroupToPGroupRepository.GetPGroupByGGroupIfExists(locus, gGroup, version).ReturnsNull();
+
+            for (var i = 0; i < 5; i++)
+            {
+                var (wasFound, _) = await gGroupToPGroupService.TryConvertGGroupToPGroup(locus, gGroup, version);
+                wasFound.Should().BeFalse();
+            }
+
+            await gGroupToPGroupRepository.Received(1).GetPGroupByGGroupIfExists(locus, gGroup, version);
+        }
+
+        [Test]
+        public async Task TryGetMetadata_AfterTheThrowingPathFailedForTheName_ReportsNotFoundFromTheSameCachedOutcome()
+        {
+            var locus = fixture.Create<Locus>();
+            var gGroup = fixture.Create<string>();
+            var version = fixture.Create<string>();
+
+            gGroupToPGroupRepository.GetPGroupByGGroupIfExists(locus, gGroup, version).ReturnsNull();
+
+            // One memo, read two ways: whichever path meets the name first pays for the lookup, and the other is served
+            // from the cache. The two must agree, or the answer would depend on which caller arrived first.
+            await gGroupToPGroupService.Invoking(s => s.ConvertGGroupToPGroup(locus, gGroup, version))
+                .Should().ThrowAsync<HlaMetadataDictionaryException>();
+
+            var (wasFound, _) = await gGroupToPGroupService.TryConvertGGroupToPGroup(locus, gGroup, version);
+
+            wasFound.Should().BeFalse();
+            await gGroupToPGroupRepository.Received(1).GetPGroupByGGroupIfExists(locus, gGroup, version);
+        }
+
+        [Test]
+        public async Task TryGetMetadata_WhenTheRepositoryFaults_PropagatesTheFaultAndDoesNotCacheIt()
+        {
+            var locus = fixture.Create<Locus>();
+            var gGroup = fixture.Create<string>();
+            var version = fixture.Create<string>();
+            var expectedPGroup = fixture.Create<string>();
+
+            var faulted = true;
+
+            // This is the whole point of having a non-throwing method as well as a throwing one: "no data for this
+            // name" is an answer, and a failed storage request is not. Reporting the second as the first would predict
+            // from an incomplete expansion, silently and with nothing logged as an error.
+            gGroupToPGroupRepository.GetPGroupByGGroupIfExists(locus, gGroup, version)
+                .Returns<IMolecularTypingToPGroupMetadata>(_ =>
+                    faulted
+                        ? throw new TimeoutException("storage is having a moment")
+                        : new MolecularTypingToPGroupMetadata(locus, gGroup, expectedPGroup));
+
+            await gGroupToPGroupService.Invoking(s => s.TryConvertGGroupToPGroup(locus, gGroup, version))
+                .Should().ThrowAsync<TimeoutException>();
+
+            faulted = false;
+            var (wasFound, pGroup) = await gGroupToPGroupService.TryConvertGGroupToPGroup(locus, gGroup, version);
+
+            wasFound.Should().BeTrue();
+            pGroup.Should().Be(expectedPGroup);
+            await gGroupToPGroupRepository.Received(2).GetPGroupByGGroupIfExists(locus, gGroup, version);
+        }
+
+        private async Task<HlaMetadataDictionaryException> ShouldFailLookup(Locus locus, string lookupName, string version)
+        {
+            try
+            {
+                await metadataService.GetCurrentAlleleNames(locus, lookupName, version);
+            }
+            catch (HlaMetadataDictionaryException exception)
+            {
+                return exception;
+            }
+
+            throw new AssertionException($"Expected a lookup of '{lookupName}' to fail, but it succeeded.");
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/HlaConversion/HlaConverterTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/HlaConversion/HlaConverterTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.GeneticData;
 using Atlas.Common.Public.Models.GeneticData;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.HLATypings;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata;
@@ -14,6 +15,7 @@ using Atlas.HlaMetadataDictionary.Test.TestHelpers.Builders;
 using Atlas.HlaMetadataDictionary.Test.TestHelpers.Builders.ScoringInfoBuilders;
 using AwesomeAssertions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
@@ -211,6 +213,150 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
 
             result.Should().BeEquivalentTo(serologyName);
         }
+
+        #region TryConvertHla
+
+        [TestCase(null)]
+        [TestCase("")]
+        public async Task TryConvertHla_HlaNameIsNullOrEmpty_ExceptionThrown(string hlaName)
+        {
+            // A missing argument is still a programming fault, not a name with no data. Parity with ConvertHla.
+            await hlaConverter.Invoking(provider => provider.TryConvertHla(DefaultLocus, hlaName, new HlaConversionBehaviour()))
+                .Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [TestCase(TargetHlaCategory.GGroup)]
+        [TestCase(TargetHlaCategory.PGroup)]
+        [TestCase(TargetHlaCategory.SmallGGroup)]
+        public async Task TryConvertHla_WhenTheNameHasNoData_ReportsNotFoundWithoutTakingTheThrowingPath(TargetHlaCategory targetHla)
+        {
+            // The three categories match prediction converts to, which is why they are the three with a non-throwing route
+            ArrangeNoDataForTheName();
+
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+            {
+                TargetHlaCategory = targetHla
+            });
+
+            wasFound.Should().BeFalse();
+            hla.Should().BeNull();
+
+            await scoringMetadataService.DidNotReceiveWithAnyArgs().GetHlaMetadata(default, default, default);
+            await smallGGroupMetadataService.DidNotReceiveWithAnyArgs().GetSmallGGroups(default, default, default);
+        }
+
+        [Test]
+        public async Task TryConvertHla_TargetIsGGroup_ReturnsMatchingGGroups()
+        {
+            var gGroups = new List<string> {"g-group-1", "g-group-2"};
+            var info = new ConsolidatedMolecularScoringInfoBuilder().WithMatchingGGroups(gGroups).Build();
+            scoringMetadataService.TryGetHlaMetadata(default, default, default)
+                .ReturnsForAnyArgs((true, BuildHlaScoringMetadata(info)));
+
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+            {
+                TargetHlaCategory = TargetHlaCategory.GGroup
+            });
+
+            wasFound.Should().BeTrue();
+            hla.Should().BeEquivalentTo(gGroups);
+        }
+
+        [Test]
+        public async Task TryConvertHla_TargetIsPGroup_ReturnsMatchingPGroups()
+        {
+            var pGroups = new List<string> {"p-group-1", "p-group-2"};
+            var info = new ConsolidatedMolecularScoringInfoBuilder().WithMatchingPGroups(pGroups).Build();
+            scoringMetadataService.TryGetHlaMetadata(default, default, default)
+                .ReturnsForAnyArgs((true, BuildHlaScoringMetadata(info)));
+
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+            {
+                TargetHlaCategory = TargetHlaCategory.PGroup
+            });
+
+            wasFound.Should().BeTrue();
+            hla.Should().BeEquivalentTo(pGroups);
+        }
+
+        [Test]
+        public async Task TryConvertHla_TargetIsSmallGGroup_ReturnsSmallGGroups()
+        {
+            var smallGGroups = new List<string> {"small-g-group-1", "small-g-group-2"};
+            smallGGroupMetadataService.TryGetSmallGGroups(default, default, default).ReturnsForAnyArgs((true, smallGGroups));
+
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+            {
+                TargetHlaCategory = TargetHlaCategory.SmallGGroup
+            });
+
+            wasFound.Should().BeTrue();
+            hla.Should().BeEquivalentTo(smallGGroups);
+        }
+
+        [Test]
+        public async Task TryConvertHla_ForANewAllele_ReportsFoundWithNoGroups()
+        {
+            // The NEW short-circuit of the throwing path, kept: a new allele is a known answer with no groups, and it
+            // must not reach a lookup service or be reported as a name with no data.
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, "NEW", new HlaConversionBehaviour
+            {
+                TargetHlaCategory = TargetHlaCategory.GGroup
+            });
+
+            wasFound.Should().BeTrue();
+            hla.Should().BeEmpty();
+
+            await scoringMetadataService.DidNotReceiveWithAnyArgs().TryGetHlaMetadata(default, default, default);
+        }
+
+        [Test]
+        public async Task TryConvertHla_TargetHasNoNonThrowingRoute_AndTheNameHasNoData_ReportsNotFound()
+        {
+            // Serology keeps the throwing path behind a catch: same answer, and its failures are too rare to be worth
+            // widening the surface for.
+            scoringMetadataService.GetHlaMetadata(default, default, default).ThrowsForAnyArgs(
+                new HlaMetadataDictionaryException(DefaultLocus, DefaultHlaName, $"Failed to lookup '{DefaultHlaName}'."));
+
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+            {
+                TargetHlaCategory = TargetHlaCategory.Serology
+            });
+
+            wasFound.Should().BeFalse();
+            hla.Should().BeNull();
+        }
+
+        [TestCase(TargetHlaCategory.GGroup)]
+        [TestCase(TargetHlaCategory.SmallGGroup)]
+        [TestCase(TargetHlaCategory.Serology)]
+        public async Task TryConvertHla_WhenTheLookupFaults_PropagatesInsteadOfReportingNoData(TargetHlaCategory targetHla)
+        {
+            // The boundary this method exists to draw, and it has to hold on both routes: a name with no data is an
+            // answer, a failed storage request is not. Swallowing the second as the first would convert an incomplete
+            // expansion into a prediction, silently.
+            var fault = new TimeoutException("storage is having a moment");
+
+            scoringMetadataService.TryGetHlaMetadata(default, default, default).ThrowsForAnyArgs(fault);
+            scoringMetadataService.GetHlaMetadata(default, default, default).ThrowsForAnyArgs(fault);
+            smallGGroupMetadataService.TryGetSmallGGroups(default, default, default).ThrowsForAnyArgs(fault);
+
+            await hlaConverter.Invoking(provider => provider.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+                {
+                    TargetHlaCategory = targetHla
+                }))
+                .Should().ThrowAsync<TimeoutException>();
+        }
+
+        private void ArrangeNoDataForTheName()
+        {
+            scoringMetadataService.TryGetHlaMetadata(default, default, default)
+                .ReturnsForAnyArgs((false, (IHlaScoringMetadata)null));
+            smallGGroupMetadataService.TryGetSmallGGroups(default, default, default)
+                .ReturnsForAnyArgs((false, (IEnumerable<string>)null));
+        }
+
+        #endregion
 
         private static IHlaScoringMetadata BuildHlaScoringMetadata(IHlaScoringInfo scoringInfo)
         {

--- a/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/HlaConversion/HlaConverterTests.cs
+++ b/Atlas.HlaMetadataDictionary.Test/UnitTests/Services/HlaConversion/HlaConverterTests.cs
@@ -42,7 +42,8 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             hlaConverter = new HlaConverter(
                 hlaNameToTwoFieldAlleleConverter,
                 scoringMetadataService,
-                smallGGroupMetadataService);
+                smallGGroupMetadataService
+            );
         }
 
         [TestCase(null)]
@@ -66,9 +67,10 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const TargetHlaCategory targetHla = TargetHlaCategory.TwoFieldAlleleIncludingExpressionSuffix;
 
             await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla
-            });
+                {
+                    TargetHlaCategory = targetHla
+                }
+            );
 
             await hlaNameToTwoFieldAlleleConverter.Received()
                 .ConvertHla(DefaultLocus, DefaultHlaName, ExpressionSuffixBehaviour.Include, Arg.Any<string>());
@@ -80,9 +82,10 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const TargetHlaCategory targetHla = TargetHlaCategory.TwoFieldAlleleExcludingExpressionSuffix;
 
             await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla
-            });
+                {
+                    TargetHlaCategory = targetHla
+                }
+            );
 
             await hlaNameToTwoFieldAlleleConverter.Received()
                 .ConvertHla(DefaultLocus, DefaultHlaName, ExpressionSuffixBehaviour.Exclude, Arg.Any<string>());
@@ -96,10 +99,11 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const string version = "version";
 
             await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             await scoringMetadataService.Received()
                 .GetHlaMetadata(DefaultLocus, DefaultHlaName, version);
@@ -109,7 +113,7 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
         [Test]
         public async Task ConvertHla_TargetIsGGroup_ReturnsMatchingGGroups()
         {
-            var gGroups = new List<string> {"g-group1", "g-group-2"};
+            var gGroups = new List<string> { "g-group1", "g-group-2" };
             var info = new ConsolidatedMolecularScoringInfoBuilder().WithMatchingGGroups(gGroups).Build();
             var metadata = BuildHlaScoringMetadata(info);
             scoringMetadataService.GetHlaMetadata(DefaultLocus, DefaultHlaName, Arg.Any<string>()).Returns(metadata);
@@ -117,10 +121,11 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const TargetHlaCategory targetHla = TargetHlaCategory.GGroup;
             const string version = "version";
             var result = await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             result.Should().BeEquivalentTo(gGroups);
         }
@@ -132,10 +137,11 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const string version = "version";
 
             await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             await smallGGroupMetadataService.Received()
                 .GetSmallGGroups(DefaultLocus, DefaultHlaName, version);
@@ -144,17 +150,18 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
         [Test]
         public async Task ConvertHla_TargetIsSmallGGroup_ReturnsSmallGGroups()
         {
-            var gGroups = new List<string> {"g-group1", "g-group-2"};
+            var gGroups = new List<string> { "g-group1", "g-group-2" };
             smallGGroupMetadataService.GetSmallGGroups(default, default, default).ReturnsForAnyArgs(gGroups);
 
             const TargetHlaCategory targetHla = TargetHlaCategory.SmallGGroup;
             const string version = "version";
 
             var result = await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             result.Should().BeEquivalentTo(gGroups);
         }
@@ -167,10 +174,11 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const string version = "version";
 
             await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             await scoringMetadataService.Received()
                 .GetHlaMetadata(DefaultLocus, DefaultHlaName, version);
@@ -184,10 +192,11 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const string version = "version";
 
             await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             await scoringMetadataService.Received()
                 .GetHlaMetadata(DefaultLocus, DefaultHlaName, version);
@@ -198,7 +207,7 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
         public async Task ConvertHla_TargetIsSerology_ReturnsMatchingSerologies()
         {
             const string serologyName = "serology";
-            var serologies = new List<SerologyEntry> {new SerologyEntry(serologyName, SerologySubtype.Associated, false)};
+            var serologies = new List<SerologyEntry> { new SerologyEntry(serologyName, SerologySubtype.Associated, false) };
             var info = new ConsolidatedMolecularScoringInfoBuilder().WithMatchingSerologies(serologies).Build();
             var metadata = BuildHlaScoringMetadata(info);
             scoringMetadataService.GetHlaMetadata(DefaultLocus, DefaultHlaName, Arg.Any<string>()).Returns(metadata);
@@ -206,10 +215,11 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             const TargetHlaCategory targetHla = TargetHlaCategory.Serology;
             const string version = "version";
             var result = await hlaConverter.ConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla,
-                HlaNomenclatureVersion = version
-            });
+                {
+                    TargetHlaCategory = targetHla,
+                    HlaNomenclatureVersion = version
+                }
+            );
 
             result.Should().BeEquivalentTo(serologyName);
         }
@@ -234,9 +244,10 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             ArrangeNoDataForTheName();
 
             var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = targetHla
-            });
+                {
+                    TargetHlaCategory = targetHla
+                }
+            );
 
             wasFound.Should().BeFalse();
             hla.Should().BeNull();
@@ -248,15 +259,16 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
         [Test]
         public async Task TryConvertHla_TargetIsGGroup_ReturnsMatchingGGroups()
         {
-            var gGroups = new List<string> {"g-group-1", "g-group-2"};
+            var gGroups = new List<string> { "g-group-1", "g-group-2" };
             var info = new ConsolidatedMolecularScoringInfoBuilder().WithMatchingGGroups(gGroups).Build();
             scoringMetadataService.TryGetHlaMetadata(default, default, default)
                 .ReturnsForAnyArgs((true, BuildHlaScoringMetadata(info)));
 
             var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = TargetHlaCategory.GGroup
-            });
+                {
+                    TargetHlaCategory = TargetHlaCategory.GGroup
+                }
+            );
 
             wasFound.Should().BeTrue();
             hla.Should().BeEquivalentTo(gGroups);
@@ -265,15 +277,16 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
         [Test]
         public async Task TryConvertHla_TargetIsPGroup_ReturnsMatchingPGroups()
         {
-            var pGroups = new List<string> {"p-group-1", "p-group-2"};
+            var pGroups = new List<string> { "p-group-1", "p-group-2" };
             var info = new ConsolidatedMolecularScoringInfoBuilder().WithMatchingPGroups(pGroups).Build();
             scoringMetadataService.TryGetHlaMetadata(default, default, default)
                 .ReturnsForAnyArgs((true, BuildHlaScoringMetadata(info)));
 
             var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = TargetHlaCategory.PGroup
-            });
+                {
+                    TargetHlaCategory = TargetHlaCategory.PGroup
+                }
+            );
 
             wasFound.Should().BeTrue();
             hla.Should().BeEquivalentTo(pGroups);
@@ -282,13 +295,14 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
         [Test]
         public async Task TryConvertHla_TargetIsSmallGGroup_ReturnsSmallGGroups()
         {
-            var smallGGroups = new List<string> {"small-g-group-1", "small-g-group-2"};
+            var smallGGroups = new List<string> { "small-g-group-1", "small-g-group-2" };
             smallGGroupMetadataService.TryGetSmallGGroups(default, default, default).ReturnsForAnyArgs((true, smallGGroups));
 
             var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = TargetHlaCategory.SmallGGroup
-            });
+                {
+                    TargetHlaCategory = TargetHlaCategory.SmallGGroup
+                }
+            );
 
             wasFound.Should().BeTrue();
             hla.Should().BeEquivalentTo(smallGGroups);
@@ -300,9 +314,10 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             // The NEW short-circuit of the throwing path, kept: a new allele is a known answer with no groups, and it
             // must not reach a lookup service or be reported as a name with no data.
             var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, "NEW", new HlaConversionBehaviour
-            {
-                TargetHlaCategory = TargetHlaCategory.GGroup
-            });
+                {
+                    TargetHlaCategory = TargetHlaCategory.GGroup
+                }
+            );
 
             wasFound.Should().BeTrue();
             hla.Should().BeEmpty();
@@ -316,25 +331,32 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             // Serology keeps the throwing path behind a catch: same answer, and its failures are too rare to be worth
             // widening the surface for.
             scoringMetadataService.GetHlaMetadata(default, default, default).ThrowsForAnyArgs(
-                new HlaMetadataDictionaryException(DefaultLocus, DefaultHlaName, $"Failed to lookup '{DefaultHlaName}'."));
+                new HlaMetadataDictionaryException(DefaultLocus, DefaultHlaName, $"Failed to lookup '{DefaultHlaName}'.")
+            );
 
             var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
-            {
-                TargetHlaCategory = TargetHlaCategory.Serology
-            });
+                {
+                    TargetHlaCategory = TargetHlaCategory.Serology
+                }
+            );
 
             wasFound.Should().BeFalse();
             hla.Should().BeNull();
         }
 
         [TestCase(TargetHlaCategory.GGroup)]
+        [TestCase(TargetHlaCategory.PGroup)]
         [TestCase(TargetHlaCategory.SmallGGroup)]
         [TestCase(TargetHlaCategory.Serology)]
         public async Task TryConvertHla_WhenTheLookupFaults_PropagatesInsteadOfReportingNoData(TargetHlaCategory targetHla)
         {
-            // The boundary this method exists to draw, and it has to hold on both routes: a name with no data is an
+            // The boundary this method exists to draw, and it has to hold on every route: a name with no data is an
             // answer, a failed storage request is not. Swallowing the second as the first would convert an incomplete
             // expansion into a prediction, silently.
+            //
+            // A raw TimeoutException is what the metadata services now emit for this, because GetMetadata no longer
+            // re-labels non-lookup failures as HlaMetadataDictionaryException. While it did, this arrangement was
+            // arranging a fault production could not produce, and the Serology case below proved nothing.
             var fault = new TimeoutException("storage is having a moment");
 
             scoringMetadataService.TryGetHlaMetadata(default, default, default).ThrowsForAnyArgs(fault);
@@ -342,10 +364,51 @@ namespace Atlas.HlaMetadataDictionary.Test.UnitTests.Services.HlaConversion
             smallGGroupMetadataService.TryGetSmallGGroups(default, default, default).ThrowsForAnyArgs(fault);
 
             await hlaConverter.Invoking(provider => provider.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+                        {
+                            TargetHlaCategory = targetHla
+                        }
+                    )
+                )
+                .Should().ThrowAsync<TimeoutException>();
+        }
+
+        [TestCase(TargetHlaCategory.TwoFieldAlleleIncludingExpressionSuffix)]
+        [TestCase(TargetHlaCategory.TwoFieldAlleleExcludingExpressionSuffix)]
+        public async Task TryConvertHla_WhenTheTwoFieldConversionFaults_PropagatesInsteadOfReportingNoData(TargetHlaCategory targetHla)
+        {
+            // Its own test rather than another case above: the two-field categories share the fallback `catch` with
+            // Serology but not the service behind it, so arranging the scoring service would leave them untouched
+            // and pass for the wrong reason.
+            hlaNameToTwoFieldAlleleConverter.ConvertHla(default, default, default, default)
+                .ThrowsForAnyArgs(new TimeoutException("storage is having a moment"));
+
+            await hlaConverter.Invoking(provider => provider.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
+                        {
+                            TargetHlaCategory = targetHla
+                        }
+                    )
+                )
+                .Should().ThrowAsync<TimeoutException>();
+        }
+
+        [TestCase(TargetHlaCategory.TwoFieldAlleleIncludingExpressionSuffix)]
+        [TestCase(TargetHlaCategory.TwoFieldAlleleExcludingExpressionSuffix)]
+        public async Task TryConvertHla_WhenTheTwoFieldNameHasNoData_ReportsNotFound(TargetHlaCategory targetHla)
+        {
+            // The other half of the same boundary. Without it, the propagation test above would still pass with the
+            // fallback `catch` deleted outright.
+            hlaNameToTwoFieldAlleleConverter.ConvertHla(default, default, default, default).ThrowsForAnyArgs(
+                new HlaMetadataDictionaryException(DefaultLocus, DefaultHlaName, $"Failed to lookup '{DefaultHlaName}'.")
+            );
+
+            var (wasFound, hla) = await hlaConverter.TryConvertHla(DefaultLocus, DefaultHlaName, new HlaConversionBehaviour
                 {
                     TargetHlaCategory = targetHla
-                }))
-                .Should().ThrowAsync<TimeoutException>();
+                }
+            );
+
+            wasFound.Should().BeFalse();
+            hla.Should().BeNull();
         }
 
         private void ArrangeNoDataForTheName()

--- a/Atlas.HlaMetadataDictionary/ExternalInterface/HlaMetadataDictionary.cs
+++ b/Atlas.HlaMetadataDictionary/ExternalInterface/HlaMetadataDictionary.cs
@@ -42,6 +42,26 @@ namespace Atlas.HlaMetadataDictionary.ExternalInterface
         /// </summary>
         public Task<string> ConvertSmallGGroupToPGroup(Locus locus, string smallGGroup);
 
+        /// <summary>
+        /// <see cref="ConvertHla"/>, <see cref="ConvertGGroupToPGroup"/> and
+        /// <see cref="ConvertSmallGGroupToPGroup"/> for a caller that treats an HLA name with no data as an <b>answer</b>
+        /// rather than an error - which Match Prediction does.
+        ///
+        /// <para>
+        /// <b>An infrastructure fault still throws.</b> That is the point of having these as well as the methods above:
+        /// a failed storage request and a missing name used to arrive as the same
+        /// <c>HlaMetadataDictionaryException</c>, so a caller that swallowed lookup failures silently treated a
+        /// transient blip as "this HLA does not exist". Here they are distinguishable.
+        /// </para>
+        /// </summary>
+        Task<(bool WasFound, IReadOnlyCollection<string> Hla)> TryConvertHla(Locus locus, string hlaName, TargetHlaCategory targetHlaCategory);
+
+        /// <inheritdoc cref="TryConvertHla"/>
+        Task<(bool WasFound, string PGroup)> TryConvertGGroupToPGroup(Locus locus, string gGroup);
+
+        /// <inheritdoc cref="TryConvertHla"/>
+        Task<(bool WasFound, string PGroup)> TryConvertSmallGGroupToPGroup(Locus locus, string smallGGroup);
+
         Task<LocusInfo<INullHandledHlaMatchingMetadata>> GetLocusHlaMatchingMetadata(Locus locus, LocusInfo<string> locusTyping);
         Task<IHlaScoringMetadata> GetHlaScoringMetadata(Locus locus, string hlaName);
         Task<string> GetDpb1TceGroup(string dpb1HlaName);
@@ -219,6 +239,31 @@ namespace Atlas.HlaMetadataDictionary.ExternalInterface
         public async Task<string> ConvertSmallGGroupToPGroup(Locus locus, string smallGGroup)
         {
             return await smallGGroupToPGroupMetadataService.ConvertSmallGGroupToPGroup(locus, smallGGroup, HlaNomenclatureVersion);
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, IReadOnlyCollection<string> Hla)> TryConvertHla(
+            Locus locus,
+            string hlaName,
+            TargetHlaCategory targetHlaCategory)
+        {
+            return await hlaConverter.TryConvertHla(locus, hlaName, new HlaConversionBehaviour
+            {
+                HlaNomenclatureVersion = HlaNomenclatureVersion,
+                TargetHlaCategory = targetHlaCategory
+            });
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, string PGroup)> TryConvertGGroupToPGroup(Locus locus, string gGroup)
+        {
+            return await gGroupToPGroupMetadataService.TryConvertGGroupToPGroup(locus, gGroup, HlaNomenclatureVersion);
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, string PGroup)> TryConvertSmallGGroupToPGroup(Locus locus, string smallGGroup)
+        {
+            return await smallGGroupToPGroupMetadataService.TryConvertSmallGGroupToPGroup(locus, smallGGroup, HlaNomenclatureVersion);
         }
 
         public async Task<IEnumerable<SerologyToAlleleMappingSummary>> GetSerologyToAlleleMappings(Locus locus, string serologyName)

--- a/Atlas.HlaMetadataDictionary/InternalExceptions/HlaCategorisationExtensions.cs
+++ b/Atlas.HlaMetadataDictionary/InternalExceptions/HlaCategorisationExtensions.cs
@@ -1,0 +1,62 @@
+using Atlas.Common.GeneticData.Hla.Models;
+using Atlas.Common.GeneticData.Hla.Services;
+using Atlas.Common.Public.Models.GeneticData;
+using Atlas.Common.Utils.Http;
+
+namespace Atlas.HlaMetadataDictionary.InternalExceptions
+{
+    /// <summary>
+    /// The categorisation service reports a name it cannot parse by throwing <see cref="AtlasHttpException"/> - a
+    /// sensible answer at the API boundary it was written for, and the wrong one here.
+    /// </summary>
+    /// <remarks>
+    /// Inside this dictionary an unparseable name is a name with no data, and it has to say so in this dictionary's
+    /// own vocabulary. <c>MetadataServiceBase.GetMetadata</c> used to re-label every exception as an
+    /// <c>HlaMetadataDictionaryException</c>, so it did not matter what came past it; now that only genuine misses
+    /// are re-thrown, an <see cref="AtlasHttpException"/> escaping a lookup would be read as an infrastructure fault
+    /// and fail a whole donor batch over one malformed donor record.
+    /// </remarks>
+    internal static class HlaCategorisationExtensions
+    {
+        /// <summary>
+        /// <see cref="IHlaCategorisationService.GetHlaTypingCategory"/>, reporting a name it cannot parse as
+        /// <see cref="InvalidHlaException"/>.
+        /// </summary>
+        public static HlaTypingCategory GetCategoryOrThrowInvalidHla(
+            this IHlaCategorisationService categorisationService,
+            Locus locus,
+            string hlaName)
+        {
+            try
+            {
+                return categorisationService.GetHlaTypingCategory(hlaName);
+            }
+            catch (AtlasHttpException)
+            {
+                throw new InvalidHlaException(locus, hlaName);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="IHlaCategorisationService.GetHlaTypingCategory"/>, reporting a name it cannot parse as
+        /// <c>false</c>. For the callers that are deciding whether a name is worth looking up at all, where "cannot
+        /// be parsed" and "is not the category I handle" are the same answer.
+        /// </summary>
+        public static bool TryGetCategory(
+            this IHlaCategorisationService categorisationService,
+            string hlaName,
+            out HlaTypingCategory category)
+        {
+            try
+            {
+                category = categorisationService.GetHlaTypingCategory(hlaName);
+                return true;
+            }
+            catch (AtlasHttpException)
+            {
+                category = default;
+                return false;
+            }
+        }
+    }
+}

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/AlleleGroupExpander.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/AlleleGroupExpander.cs
@@ -28,7 +28,7 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             IAlleleGroupsMetadataRepository alleleGroupsMetadataRepository,
             IHlaCategorisationService hlaCategorisationService,
             IPersistentCacheProvider cacheProvider)
-        : base(CacheKey, cacheProvider)
+            : base(CacheKey, cacheProvider)
         {
             this.alleleGroupsMetadataRepository = alleleGroupsMetadataRepository;
             this.hlaCategorisationService = hlaCategorisationService;
@@ -58,8 +58,10 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
 
         private bool IsAlleleGroup(string lookupName)
         {
-            var category = hlaCategorisationService.GetHlaTypingCategory(lookupName);
-            return new[]{HlaTypingCategory.GGroup, HlaTypingCategory.PGroup, HlaTypingCategory.SmallGGroup}.Contains(category);
+            // TryGetCategory, not GetHlaTypingCategory: a name this service cannot parse is not an allele group, and
+            // is not an infrastructure fault either. See AlleleNamesMetadataService.LookupNameIsValid.
+            return hlaCategorisationService.TryGetCategory(lookupName, out var category)
+                && new[] { HlaTypingCategory.GGroup, HlaTypingCategory.PGroup, HlaTypingCategory.SmallGGroup }.Contains(category);
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/AlleleNamesMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/AlleleNamesMetadataService.cs
@@ -24,7 +24,7 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         private readonly IHlaCategorisationService hlaCategorisationService;
 
         public AlleleNamesMetadataService(
-            IAlleleNamesMetadataRepository alleleNamesMetadataRepository, 
+            IAlleleNamesMetadataRepository alleleNamesMetadataRepository,
             IHlaCategorisationService hlaCategorisationService,
             IPersistentCacheProvider cacheProvider)
             : base(CacheKey, cacheProvider)
@@ -40,8 +40,11 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
 
         protected override bool LookupNameIsValid(string lookupName)
         {
-            return !string.IsNullOrEmpty(lookupName) &&
-                   hlaCategorisationService.GetHlaTypingCategory(lookupName) == HlaTypingCategory.Allele;
+            // TryGetCategory, not GetHlaTypingCategory: a name this service cannot parse is simply not an allele
+            // name, and must not leave here as the AtlasHttpException the categoriser reports it with.
+            return !string.IsNullOrEmpty(lookupName)
+                && hlaCategorisationService.TryGetCategory(lookupName, out var category)
+                && category == HlaTypingCategory.Allele;
         }
 
         protected override async Task<IEnumerable<string>> PerformLookup(Locus locus, string lookupName, string hlaNomenclatureVersion)

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/GGroupToPGroupMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/GGroupToPGroupMetadataService.cs
@@ -15,6 +15,16 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         /// reliant on the fact that each G Group will only have 1 or 0 corresponding P Groups.
         /// </summary>
         Task<string> ConvertGGroupToPGroup(Locus locus, string gGroupLookupName, string hlaNomenclatureVersion);
+
+        /// <summary>
+        /// <see cref="ConvertGGroupToPGroup"/> for a caller that treats an unrecognised G group as an answer rather
+        /// than an error.
+        /// </summary>
+        /// <returns>
+        /// <c>(false, null)</c> where the G group is not in the data. Note that <c>(true, null)</c> is a distinct and
+        /// legitimate outcome: a G group of null-expressing alleles is recognised and has no P group.
+        /// </returns>
+        Task<(bool WasFound, string PGroup)> TryConvertGGroupToPGroup(Locus locus, string gGroupLookupName, string hlaNomenclatureVersion);
     }
 
     internal class GGroupToPGroupMetadataService : MetadataServiceBase<string>, IGGroupToPGroupMetadataService
@@ -56,6 +66,20 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             }
 
             return await GetMetadata(locus, gGroupLookupName, hlaNomenclatureVersion);
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, string PGroup)> TryConvertGGroupToPGroup(
+            Locus locus,
+            string gGroupLookupName,
+            string hlaNomenclatureVersion)
+        {
+            if (gGroupLookupName == null)
+            {
+                return (true, null);
+            }
+
+            return await TryGetMetadata(locus, gGroupLookupName, hlaNomenclatureVersion);
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/HlaMatchingMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/HlaMatchingMetadataService.cs
@@ -2,6 +2,7 @@
 using Atlas.Common.GeneticData;
 using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 using Atlas.MultipleAlleleCodeDictionary.ExternalInterface;
@@ -63,6 +64,13 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             string lookupName,
             List<IHlaMatchingMetadata> metadata)
         {
+            // See HlaScoringMetadataService.ConsolidateHlaMetadata: an empty list is a name with no data, and has to
+            // say so, now that GetMetadata no longer re-labels the First() failure as one.
+            if (metadata.Count == 0)
+            {
+                throw new InvalidHlaException(locus, lookupName);
+            }
+
             var typingMethod = metadata
                 .First()
                 .TypingMethod;

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/HlaScoringMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/HlaScoringMetadataService.cs
@@ -2,6 +2,7 @@
 using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata.ScoringMetadata;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 using Atlas.MultipleAlleleCodeDictionary.ExternalInterface;
@@ -41,20 +42,21 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             IAlleleGroupExpander alleleGroupExpander,
             IPersistentCacheProvider cacheProvider,
             HlaMetadataDictionarySettings options
-            ) : base(
-                hlaScoringMetadataRepository,
-                alleleNamesMetadataService,
-                hlaCategorisationService,
-                alleleNamesExtractor,
-                macDictionary,
-                alleleGroupExpander,
-                CacheKey,
-                cacheProvider,
-                options)
+        ) : base(
+            hlaScoringMetadataRepository,
+            alleleNamesMetadataService,
+            hlaCategorisationService,
+            alleleNamesExtractor,
+            macDictionary,
+            alleleGroupExpander,
+            CacheKey,
+            cacheProvider,
+            options
+        )
         {
             this.hlaScoringMetadataRepository = hlaScoringMetadataRepository;
         }
-        
+
         public async Task<IDictionary<Locus, List<string>>> GetAllGGroups(string hlaNomenclatureVersion)
         {
             return await hlaScoringMetadataRepository.GetAllGGroups(hlaNomenclatureVersion);
@@ -70,7 +72,15 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             string lookupName,
             List<IHlaScoringMetadata> metadata)
         {
-            var hlaTypingCategory = HlaCategorisationService.GetHlaTypingCategory(lookupName);
+            // Nothing to consolidate is a name with no data. Said explicitly because the alternative is an
+            // InvalidOperationException out of the Single() below, which GetMetadata used to re-label as a missing
+            // name and no longer does - it would now fail the caller's whole batch instead.
+            if (metadata.Count == 0)
+            {
+                throw new InvalidHlaException(locus, lookupName);
+            }
+
+            var hlaTypingCategory = HlaCategorisationService.GetCategoryOrThrowInvalidHla(locus, lookupName);
             var scoringInfos = metadata.Select(result => result.HlaScoringInfo).ToList();
 
             switch (hlaTypingCategory)
@@ -96,7 +106,9 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
                     return metadata.Single();
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    // A category with no scoring strategy is a name this service cannot answer for - not an
+                    // infrastructure fault, and no longer re-labelled as a lookup miss by GetMetadata.
+                    throw new InvalidHlaException(locus, lookupName);
             }
         }
 
@@ -110,7 +122,8 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
 
             var multipleAlleleScoringInfo = new MultipleAlleleScoringInfo(
                 alleleScoringInfos,
-                matchingSerologies);
+                matchingSerologies
+            );
 
             return new HlaScoringMetadata(
                 locus,
@@ -134,7 +147,8 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             var consolidatedMolecularScoringInfo = new ConsolidatedMolecularScoringInfo(
                 matchingPGroups,
                 matchingGGroups,
-                matchingSerologies);
+                matchingSerologies
+            );
 
             return new HlaScoringMetadata(
                 locus,

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Lookups/AlleleStringLookup.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Lookups/AlleleStringLookup.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Atlas.Common.GeneticData;
 using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.Common.Public.Models.GeneticData;
+using Atlas.Common.Utils.Http;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 
 namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval.Lookups
@@ -23,7 +26,19 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval.Lookups
 
         protected override async Task<List<string>> GetAlleleLookupNames(Locus locus, string lookupName, string hlaNomenclatureVersion)
         {
-            return await Task.Run(() => alleleNamesExtractor.GetAlleleNamesFromAlleleString(lookupName).ToList());
+            try
+            {
+                return await Task.Run(() => alleleNamesExtractor.GetAlleleNamesFromAlleleString(lookupName).ToList());
+            }
+            // The extractor re-categorises the string and splits it, and reports a string it cannot use in the
+            // vocabulary of whichever step objected: AtlasHttpException from the categoriser, ArgumentException from
+            // the splitter for a string that does not hold two well-formed alleles. Both mean the same thing here -
+            // this name has no data - and neither is an HlaMetadataDictionaryException, so without this an unusable
+            // allele string would leave as an infrastructure fault. Same reasoning as MacLookup.
+            catch (Exception e) when (e is AtlasHttpException or ArgumentException)
+            {
+                throw new InvalidHlaException(locus, lookupName);
+            }
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Lookups/HlaLookupFactory.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Lookups/HlaLookupFactory.cs
@@ -1,15 +1,18 @@
 ﻿using Atlas.Common.GeneticData.Hla.Models;
 using Atlas.Common.GeneticData.Hla.Services;
+using Atlas.Common.Public.Models.GeneticData;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 using Atlas.MultipleAlleleCodeDictionary.ExternalInterface;
-using System;
 
 namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval.Lookups
 {
     internal static class HlaLookupFactory
     {
         public static HlaLookupBase GetLookupByHlaTypingCategory(
+            Locus locus,
+            string lookupName,
             HlaTypingCategory category,
             IHlaMetadataRepository hlaMetadataRepository,
             IAlleleNamesMetadataService alleleNamesMetadataService,
@@ -29,8 +32,9 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval.Lookups
                 HlaTypingCategory.GGroup => new AlleleGroupLookup(hlaMetadataRepository, alleleNamesMetadataService, alleleGroupExpander),
                 HlaTypingCategory.SmallGGroup => new AlleleGroupLookup(hlaMetadataRepository, alleleNamesMetadataService, alleleGroupExpander),
                 HlaTypingCategory.NEW => new NewAlleleLookup(hlaMetadataRepository), 
-                _ => throw new ArgumentException(
-                    $"Dictionary lookup cannot be performed for HLA typing category: {category}.")
+                // A category this dictionary cannot look up is a name with no data, not an infrastructure fault. As an
+                // ArgumentException it only reached callers as a missing name because GetMetadata re-labelled it.
+                _ => throw new InvalidHlaException(locus, lookupName)
             };
         }
     }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Lookups/MacLookup.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/Lookups/MacLookup.cs
@@ -1,6 +1,9 @@
 ﻿using Atlas.Common.GeneticData;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
+using Atlas.MultipleAlleleCodeDictionary;
 using Atlas.MultipleAlleleCodeDictionary.ExternalInterface;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,7 +26,19 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval.Lookups
 
         protected override async Task<List<string>> GetAlleleLookupNames(Locus locus, string lookupName, string hlaNomenclatureVersion)
         {
-            return (await macDictionary.GetHlaFromMac(lookupName)).ToList();
+            try
+            {
+                return (await macDictionary.GetHlaFromMac(lookupName)).ToList();
+            }
+            // The MAC dictionary has its own vocabulary for "not in the store", and neither term of it is an
+            // HlaMetadataDictionaryException. While GetMetadata re-labelled everything that did not matter; now it
+            // does, and an unrecognised MAC would otherwise leave here as an infrastructure fault and fail the
+            // request rather than being reported as a name with no data. Anything else - a failed storage request
+            // inside the MAC store - is left alone, which is the whole point.
+            catch (Exception e) when (e is MacNotFoundException or ArgumentException)
+            {
+                throw new InvalidHlaException(locus, lookupName);
+            }
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/MetadataServiceBase.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/MetadataServiceBase.cs
@@ -1,7 +1,9 @@
 ﻿using Atlas.Common.Caching;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using LazyCache;
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Atlas.Common.GeneticData.Hla.Services.AlleleNameUtils;
 using Atlas.Common.Public.Models.GeneticData;
@@ -40,6 +42,56 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             }
         }
 
+        /// <summary>
+        /// <see cref="GetMetadata"/>, for a caller that treats "this HLA name has no data" as an answer rather than as
+        /// an error
+        /// </summary>
+        /// <returns>
+        /// <c>(true, value)</c>, or <c>(false, default)</c> where the name has no data - which includes a name this
+        /// service does not consider a valid lookup name, because to a caller converting HLA the two are the same
+        /// outcome, and because <see cref="GetMetadata"/> has always made them the same outcome by wrapping both.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// Additive, and <see cref="GetMetadata"/> is untouched: the throwing path is load-bearing for
+        /// <c>DonorHlaExpander</c>, <c>SearchRunner</c> and <c>RepeatSearchRunner</c>, which use
+        /// <see cref="HlaMetadataDictionaryException"/> as an expected-error pathway.
+        /// </para>
+        /// <para>
+        /// <b>An infrastructure fault still throws</b>, and that is the point of having this as well as
+        /// <see cref="GetMetadata"/>. Today a failed storage request is wrapped into the same exception as a missing
+        /// name, so a caller that swallows lookup failures - <c>HlaConverterBase</c> does exactly that - silently treats
+        /// a transient blip as "this HLA does not exist" and predicts from an incomplete expansion. Here the two are
+        /// distinguishable for the first time: not-found comes back as <c>false</c>, and anything else propagates.
+        /// </para>
+        /// </remarks>
+        protected async Task<(bool WasFound, T Value)> TryGetMetadata(Locus locus, string rawLookupName, string hlaNomenclatureVersion)
+        {
+            if (rawLookupName == newAllele)
+            {
+                return (true, default);
+            }
+
+            var formattedLookupName = FormatLookupName(rawLookupName);
+            var key = BuildCacheKey(locus, formattedLookupName, hlaNomenclatureVersion);
+
+            var cachedOutcome = cache.Get<LookupOutcome>(key);
+            if (cachedOutcome != null)
+            {
+                return cachedOutcome.ValueOrNotFound();
+            }
+
+            if (!LookupNameIsValid(formattedLookupName))
+            {
+                return (false, default);
+            }
+
+            var outcome = await cache.GetOrAddAsync(
+                key, () => Lookup(locus, formattedLookupName, hlaNomenclatureVersion), GetMemoryCacheOptions());
+
+            return outcome.ValueOrNotFound();
+        }
+
         protected abstract bool LookupNameIsValid(string lookupName);
 
         protected abstract Task<T> PerformLookup(Locus locus, string lookupName, string hlaNomenclatureVersion);
@@ -53,18 +105,93 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         private async Task<T> GetOrAddCachedMetadata(Locus locus, string formattedLookupName, string hlaNomenclatureVersion)
         {
             var key = BuildCacheKey(locus, formattedLookupName, hlaNomenclatureVersion);
-            var existingRecord = cache.Get<T>(key);
-            if (existingRecord != null)
+
+            // The cached item is an OUTCOME, not a T, and that one change fixes two things the shipped
+            // `cache.Get<T>(key) != null` test could not express.
+            //
+            // 1. A name that is not in the data is now remembered. PerformLookup throws for it, LazyCache removes an
+            //    entry whose factory threw, and so the next donor carrying the same bad name repeated the whole thing:
+            //    the storage request, two throws, the logged event and - because the HF sets are at nomenclature 3480
+            //    while the refresh runs 3650 - the retry at the other version. 
+            // 2. A lookup that legitimately returns null is now served from the cache. `cache.Get<T>,` cannot tell "not
+            //    cached" from "cached, and the answer is null", so those were re-fetched forever.
+            var cachedOutcome = cache.Get<LookupOutcome>(key);
+            if (cachedOutcome != null)
             {
-                return existingRecord;
+                return cachedOutcome.ValueOrThrow();
             }
 
             if (!LookupNameIsValid(formattedLookupName))
             {
                 throw new ArgumentException($"{formattedLookupName} at locus {locus} is not a valid lookup name.");
             }
-            
-            return await cache.GetOrAddAsync(key, () => PerformLookup(locus, formattedLookupName, hlaNomenclatureVersion), GetMemoryCacheOptions());
+
+            var outcome = await cache.GetOrAddAsync(
+                key, () => Lookup(locus, formattedLookupName, hlaNomenclatureVersion), GetMemoryCacheOptions());
+
+            return outcome.ValueOrThrow();
+        }
+
+        /// <summary>
+        /// <see cref="PerformLookup"/>, with "this HLA name has no data" turned into a value the cache can hold.
+        /// </summary>
+        /// <remarks>
+        /// The boundary is <see cref="HlaMetadataDictionaryException"/> and its subclasses - which is what
+        /// this dictionary throws to say a name is not in the data, <see cref="InvalidHlaException"/> included. Anything
+        /// else is an infrastructure fault: a storage request that failed, a timeout, a serialisation error. Those are
+        /// deliberately left to propagate out of the factory, so <c>LazyCache</c> evicts the entry and the next caller
+        /// retries - caching a transient fault for the cache lifetime would turn a blip into an outage.
+        ///
+        /// <para>
+        /// The exception that finally escapes <see cref="GetMetadata"/> is unchanged, deliberately: <c>DonorHlaExpander</c> passes
+        /// <see cref="HlaMetadataDictionaryException"/> as a generic type argument to <c>ProcessBatchAsyncWithAnticipatedExceptions</c> -
+        /// it IS the per-donor skip mechanism - and <c>SearchRunner</c> and <c>RepeatSearchRunner</c> use it as an expected-error pathway that
+        /// completes the message rather than dead-lettering it. Narrowing what escapes would silently turn a skipped
+        /// donor into a failed batch, so it is a separate change with its own evidence.
+        /// </para>
+        /// </remarks>
+        private async Task<LookupOutcome> Lookup(Locus locus, string lookupName, string hlaNomenclatureVersion)
+        {
+            try
+            {
+                return LookupOutcome.Found(await PerformLookup(locus, lookupName, hlaNomenclatureVersion));
+            }
+            catch (HlaMetadataDictionaryException nameNotFound)
+            {
+                return LookupOutcome.NotFound(nameNotFound);
+            }
+        }
+
+        /// <summary>What a lookup produced: a value, or the reason the name has no value. Both are cacheable.</summary>
+        private sealed class LookupOutcome
+        {
+            private readonly T value;
+            private readonly ExceptionDispatchInfo notFound;
+
+            private LookupOutcome(T value, ExceptionDispatchInfo notFound)
+            {
+                this.value = value;
+                this.notFound = notFound;
+            }
+
+            public static LookupOutcome Found(T value) => new(value, null);
+
+            public static LookupOutcome NotFound(HlaMetadataDictionaryException exception) =>
+                new(default, ExceptionDispatchInfo.Capture(exception));
+
+            /// <summary>
+            /// The value, or the original exception re-thrown. Captured rather than stored bare so that the first
+            /// failure's stack survives every later re-throw of it, which a plain <c>throw stored;</c> would reset.
+            /// </summary>
+            public T ValueOrThrow()
+            {
+                notFound?.Throw();
+
+                return value;
+            }
+
+            /// <summary>The same outcome, as data rather than as an exception. See <c>TryGetMetadata</c>.</summary>
+            public (bool WasFound, T Value) ValueOrNotFound() => notFound == null ? (true, value) : (false, default);
         }
 
         protected virtual MemoryCacheEntryOptions GetMemoryCacheOptions() => new MemoryCacheEntryOptions {

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/MetadataServiceBase.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/MetadataServiceBase.cs
@@ -23,6 +23,19 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             cache = cacheProvider.Cache;
         }
 
+        /// <remarks>
+        /// <see cref="HlaMetadataDictionaryException"/> means one thing and one thing only: <b>this HLA name has no
+        /// data</b>. Only that is caught and re-thrown with the name the caller actually asked about - a nested lookup
+        /// reports the expanded allele it failed on, which is rarely the name the caller would recognise.
+        ///
+        /// <para>
+        /// Everything else leaves as itself. This used to be a <c>catch (Exception)</c>, which re-labelled a failed
+        /// storage request as a missing name, and there was then no way for anyone above to tell the two apart: the
+        /// matching algorithm skipped a donor that a blip had hidden, and Match Prediction predicted from an
+        /// incomplete expansion. A <c>RequestFailedException</c> now arrives as a <c>RequestFailedException</c>, which
+        /// is also what the type-keyed Polly policies used elsewhere in this codebase expect to see.
+        /// </para>
+        /// </remarks>
         protected async Task<T> GetMetadata(Locus locus, string rawLookupName, string hlaNomenclatureVersion)
         {
             try
@@ -35,10 +48,10 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
                 var formattedLookupName = FormatLookupName(rawLookupName);
                 return await GetOrAddCachedMetadata(locus, formattedLookupName, hlaNomenclatureVersion);
             }
-            catch (Exception ex)
+            catch (HlaMetadataDictionaryException nameNotFound)
             {
                 var msg = $"Failed to lookup '{rawLookupName}' at locus {locus}.";
-                throw new HlaMetadataDictionaryException(locus, rawLookupName, msg, ex);
+                throw new HlaMetadataDictionaryException(locus, rawLookupName, msg, nameNotFound);
             }
         }
 
@@ -49,20 +62,17 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         /// <returns>
         /// <c>(true, value)</c>, or <c>(false, default)</c> where the name has no data - which includes a name this
         /// service does not consider a valid lookup name, because to a caller converting HLA the two are the same
-        /// outcome, and because <see cref="GetMetadata"/> has always made them the same outcome by wrapping both.
+        /// outcome.
         /// </returns>
         /// <remarks>
         /// <para>
-        /// Additive, and <see cref="GetMetadata"/> is untouched: the throwing path is load-bearing for
-        /// <c>DonorHlaExpander</c>, <c>SearchRunner</c> and <c>RepeatSearchRunner</c>, which use
-        /// <see cref="HlaMetadataDictionaryException"/> as an expected-error pathway.
+        /// Additive: the throwing path is load-bearing for <c>DonorHlaExpander</c>, <c>SearchRunner</c> and
+        /// <c>RepeatSearchRunner</c>, which use <see cref="HlaMetadataDictionaryException"/> as an expected-error
+        /// pathway. Both routes read one cached outcome, so whichever caller meets a bad name first pays for it.
         /// </para>
         /// <para>
-        /// <b>An infrastructure fault still throws</b>, and that is the point of having this as well as
-        /// <see cref="GetMetadata"/>. Today a failed storage request is wrapped into the same exception as a missing
-        /// name, so a caller that swallows lookup failures - <c>HlaConverterBase</c> does exactly that - silently treats
-        /// a transient blip as "this HLA does not exist" and predicts from an incomplete expansion. Here the two are
-        /// distinguishable for the first time: not-found comes back as <c>false</c>, and anything else propagates.
+        /// <b>An infrastructure fault throws</b>, and that is the point of having this as well as
+        /// <see cref="GetMetadata"/>. Not-found comes back as <c>false</c>; anything else propagates as itself.
         /// </para>
         /// </remarks>
         protected async Task<(bool WasFound, T Value)> TryGetMetadata(Locus locus, string rawLookupName, string hlaNomenclatureVersion)
@@ -72,24 +82,9 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
                 return (true, default);
             }
 
-            var formattedLookupName = FormatLookupName(rawLookupName);
-            var key = BuildCacheKey(locus, formattedLookupName, hlaNomenclatureVersion);
+            var outcome = await GetOrAddCachedOutcome(locus, FormatLookupName(rawLookupName), hlaNomenclatureVersion);
 
-            var cachedOutcome = cache.Get<LookupOutcome>(key);
-            if (cachedOutcome != null)
-            {
-                return cachedOutcome.ValueOrNotFound();
-            }
-
-            if (!LookupNameIsValid(formattedLookupName))
-            {
-                return (false, default);
-            }
-
-            var outcome = await cache.GetOrAddAsync(
-                key, () => Lookup(locus, formattedLookupName, hlaNomenclatureVersion), GetMemoryCacheOptions());
-
-            return outcome.ValueOrNotFound();
+            return outcome?.ValueOrNotFound() ?? (false, default);
         }
 
         protected abstract bool LookupNameIsValid(string lookupName);
@@ -98,38 +93,68 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
 
         private static string FormatLookupName(string lookupName)
         {
-            var lookupNameWithoutAsterisk = AlleleSplitter.RemovePrefix(lookupName?.Trim());
+            // Nothing to format, and nothing below here survives a null. This used to be moot: the formatting threw a
+            // NullReferenceException and GetMetadata re-labelled it as a lookup failure along with everything else.
+            // Now only genuine misses are re-labelled, so an untyped locus has to reach LookupNameIsValid and be
+            // reported as the missing name it is - the same answer an empty string already gets.
+            if (string.IsNullOrWhiteSpace(lookupName))
+            {
+                return lookupName;
+            }
+
+            var lookupNameWithoutAsterisk = AlleleSplitter.RemovePrefix(lookupName.Trim());
             return NullAlleleHandling.GetOriginalAlleleFromCombinedName(lookupNameWithoutAsterisk);
         }
 
         private async Task<T> GetOrAddCachedMetadata(Locus locus, string formattedLookupName, string hlaNomenclatureVersion)
         {
+            var outcome = await GetOrAddCachedOutcome(locus, formattedLookupName, hlaNomenclatureVersion);
+
+            // Not-found, not a programming fault: the same case TryGetMetadata reports as `(false, default)`, and the
+            // two routes have to agree on it. It was an ArgumentException, which only reached callers as a missing
+            // name because GetMetadata used to re-label everything.
+            return outcome == null
+                ? throw new InvalidHlaException(locus, formattedLookupName)
+                : outcome.ValueOrThrow();
+        }
+
+        /// <summary>
+        /// The one cache path, read two ways. <see cref="GetMetadata"/> and <see cref="TryGetMetadata"/> differ only in
+        /// how they report a name with no data, so they must not differ in how they cache one - a caching change made
+        /// in one of two near-identical copies is how the throwing and non-throwing routes would drift apart.
+        /// </summary>
+        /// <returns>
+        /// The outcome, or <c>null</c> where this service does not consider the name a valid lookup name at all -
+        /// which each caller reports in its own way. Unambiguous, because <see cref="Lookup"/> never returns null.
+        /// </returns>
+        /// <remarks>
+        /// The cached item is an OUTCOME, not a T, and that one change fixes two things the shipped
+        /// `cache.Get&lt;T&gt;(key) != null` test could not express.
+        ///
+        /// <para>
+        /// 1. A name that is not in the data is now remembered. PerformLookup throws for it, LazyCache removes an
+        /// entry whose factory threw, and so the next donor carrying the same bad name repeated the whole thing: the
+        /// storage request, two throws, the logged event and - because the HF sets are at nomenclature 3480 while the
+        /// refresh runs 3650 - the retry at the other version.
+        /// </para>
+        /// <para>
+        /// 2. A lookup that legitimately returns null is now served from the cache. `cache.Get&lt;T&gt;` cannot tell
+        /// "not cached" from "cached, and the answer is null", so those were re-fetched forever.
+        /// </para>
+        /// </remarks>
+        private async Task<LookupOutcome> GetOrAddCachedOutcome(Locus locus, string formattedLookupName, string hlaNomenclatureVersion)
+        {
             var key = BuildCacheKey(locus, formattedLookupName, hlaNomenclatureVersion);
 
-            // The cached item is an OUTCOME, not a T, and that one change fixes two things the shipped
-            // `cache.Get<T>(key) != null` test could not express.
-            //
-            // 1. A name that is not in the data is now remembered. PerformLookup throws for it, LazyCache removes an
-            //    entry whose factory threw, and so the next donor carrying the same bad name repeated the whole thing:
-            //    the storage request, two throws, the logged event and - because the HF sets are at nomenclature 3480
-            //    while the refresh runs 3650 - the retry at the other version. 
-            // 2. A lookup that legitimately returns null is now served from the cache. `cache.Get<T>,` cannot tell "not
-            //    cached" from "cached, and the answer is null", so those were re-fetched forever.
             var cachedOutcome = cache.Get<LookupOutcome>(key);
             if (cachedOutcome != null)
             {
-                return cachedOutcome.ValueOrThrow();
+                return cachedOutcome;
             }
 
-            if (!LookupNameIsValid(formattedLookupName))
-            {
-                throw new ArgumentException($"{formattedLookupName} at locus {locus} is not a valid lookup name.");
-            }
-
-            var outcome = await cache.GetOrAddAsync(
-                key, () => Lookup(locus, formattedLookupName, hlaNomenclatureVersion), GetMemoryCacheOptions());
-
-            return outcome.ValueOrThrow();
+            return LookupNameIsValid(formattedLookupName)
+                ? await cache.GetOrAddAsync(key, () => Lookup(locus, formattedLookupName, hlaNomenclatureVersion), GetMemoryCacheOptions())
+                : null;
         }
 
         /// <summary>
@@ -143,11 +168,13 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         /// retries - caching a transient fault for the cache lifetime would turn a blip into an outage.
         ///
         /// <para>
-        /// The exception that finally escapes <see cref="GetMetadata"/> is unchanged, deliberately: <c>DonorHlaExpander</c> passes
-        /// <see cref="HlaMetadataDictionaryException"/> as a generic type argument to <c>ProcessBatchAsyncWithAnticipatedExceptions</c> -
-        /// it IS the per-donor skip mechanism - and <c>SearchRunner</c> and <c>RepeatSearchRunner</c> use it as an expected-error pathway that
-        /// completes the message rather than dead-lettering it. Narrowing what escapes would silently turn a skipped
-        /// donor into a failed batch, so it is a separate change with its own evidence.
+        /// That boundary only holds because <see cref="GetMetadata"/> no longer re-labels every exception as an
+        /// <see cref="HlaMetadataDictionaryException"/>. While it did, a nested lookup - <c>AlleleNamesLookupBase</c>
+        /// and <c>AlleleGroupLookup</c> both make one - handed this catch a wrapped storage fault that was
+        /// indistinguishable from a missing name, and it was then cached as one for the lifetime of the persistent
+        /// cache. Every site that means "no data" therefore has to say so with this exception and nothing else; see
+        /// <c>MacLookup</c> and <c>SearchRelatedMetadataServiceBase.GetHlaLookup</c> for the two that had to be
+        /// brought into line.
         /// </para>
         /// </remarks>
         private async Task<LookupOutcome> Lookup(Locus locus, string lookupName, string hlaNomenclatureVersion)
@@ -180,9 +207,16 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
                 new(default, ExceptionDispatchInfo.Capture(exception));
 
             /// <summary>
-            /// The value, or the original exception re-thrown. Captured rather than stored bare so that the first
-            /// failure's stack survives every later re-throw of it, which a plain <c>throw stored;</c> would reset.
+            /// The value, or the original exception re-thrown. Captured rather than stored bare so that each re-throw
+            /// reproduces the first failure's stack, which a plain <c>throw stored;</c> would reset. This is what
+            /// <c>System.Lazy&lt;T&gt;</c> does with a cached failure, and is safe for the same reason: the runtime
+            /// freezes the captured frames and clones them per thread.
             /// </summary>
+            /// <remarks>
+            /// The cached exception INSTANCE is shared, though, so read a stack trace from the exception you caught,
+            /// not from the inner exception of one later. Under concurrent re-throws of the same cached outcome the
+            /// inner frames are not attributable; the type, the message and each caller's own wrapper are.
+            /// </remarks>
             public T ValueOrThrow()
             {
                 notFound?.Throw();
@@ -194,9 +228,9 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             public (bool WasFound, T Value) ValueOrNotFound() => notFound == null ? (true, value) : (false, default);
         }
 
-        protected virtual MemoryCacheEntryOptions GetMemoryCacheOptions() => new MemoryCacheEntryOptions {
-            
-            AbsoluteExpiration = DateTimeOffset.Now.AddSeconds(cache.DefaultCachePolicy.DefaultCacheDurationSeconds) 
+        protected virtual MemoryCacheEntryOptions GetMemoryCacheOptions() => new MemoryCacheEntryOptions
+        {
+            AbsoluteExpiration = DateTimeOffset.Now.AddSeconds(cache.DefaultCachePolicy.DefaultCacheDurationSeconds)
         };
 
         private string BuildCacheKey(Locus locus, string lookupName, string hlaNomenclatureVersion)

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SearchRelatedMetadataServiceBase.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SearchRelatedMetadataServiceBase.cs
@@ -2,6 +2,7 @@
 using Atlas.Common.GeneticData;
 using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
 using Atlas.HlaMetadataDictionary.Services.DataRetrieval.Lookups;
@@ -44,7 +45,7 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         private readonly IMacDictionary macDictionary;
         private readonly IAlleleGroupExpander alleleGroupExpander;
 
-        private readonly SearchRelatedMetadataServiceSettings options; 
+        private readonly SearchRelatedMetadataServiceSettings options;
 
         protected SearchRelatedMetadataServiceBase(
             IHlaMetadataRepository hlaMetadataRepository,
@@ -56,7 +57,7 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             string perTypeCacheKey,
             IPersistentCacheProvider cacheProvider,
             HlaMetadataDictionarySettings options
-            )
+        )
             : base(perTypeCacheKey, cacheProvider)
         {
             this.hlaMetadataRepository = hlaMetadataRepository;
@@ -89,25 +90,30 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
 
         protected override async Task<THlaMetadata> PerformLookup(Locus locus, string lookupName, string hlaNomenclatureVersion)
         {
-            var dictionaryLookup = GetHlaLookup(lookupName);
+            var dictionaryLookup = GetHlaLookup(locus, lookupName);
             var metadataRows = await dictionaryLookup.PerformLookupAsync(locus, lookupName, hlaNomenclatureVersion);
             var metadata = ConvertMetadataRowsToMetadata(metadataRows).ToList();
 
             return ConsolidateHlaMetadata(locus, lookupName, metadata);
         }
 
-        private HlaLookupBase GetHlaLookup(string lookupName)
+        private HlaLookupBase GetHlaLookup(Locus locus, string lookupName)
         {
-            var hlaTypingCategory = HlaCategorisationService.GetHlaTypingCategory(lookupName);
+            // A name whose category cannot be determined is a name with no data, and has to say so as one: the
+            // categoriser reports it with an AtlasHttpException, which would now escape as an infrastructure fault.
+            var hlaTypingCategory = HlaCategorisationService.GetCategoryOrThrowInvalidHla(locus, lookupName);
 
             return HlaLookupFactory
                 .GetLookupByHlaTypingCategory(
+                    locus,
+                    lookupName,
                     hlaTypingCategory,
                     hlaMetadataRepository,
                     alleleNamesMetadataService,
                     alleleNamesExtractor,
                     macDictionary,
-                    alleleGroupExpander);
+                    alleleGroupExpander
+                );
         }
 
         protected override MemoryCacheEntryOptions GetMemoryCacheOptions() => options.CacheSlidingExpirationInSeconds == null

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SearchRelatedMetadataServiceBase.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SearchRelatedMetadataServiceBase.cs
@@ -19,6 +19,12 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
     internal interface ISearchRelatedMetadataService<THlaMetadata> where THlaMetadata : IHlaMetadata
     {
         Task<THlaMetadata> GetHlaMetadata(Locus locus, string hlaName, string hlaNomenclatureVersion);
+
+        /// <summary>
+        /// <see cref="GetHlaMetadata"/> for a caller that treats an unknown HLA name as an answer.
+        /// see <c>MetadataServiceBase.TryGetMetadata</c> for why an infrastructure fault still throws.
+        /// </summary>
+        Task<(bool WasFound, THlaMetadata Metadata)> TryGetHlaMetadata(Locus locus, string hlaName, string hlaNomenclatureVersion);
     }
 
     /// <summary>
@@ -65,6 +71,15 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         public async Task<THlaMetadata> GetHlaMetadata(Locus locus, string hlaName, string hlaNomenclatureVersion)
         {
             return await GetMetadata(locus, hlaName, hlaNomenclatureVersion);
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, THlaMetadata Metadata)> TryGetHlaMetadata(
+            Locus locus,
+            string hlaName,
+            string hlaNomenclatureVersion)
+        {
+            return await TryGetMetadata(locus, hlaName, hlaNomenclatureVersion);
         }
 
         protected override bool LookupNameIsValid(string lookupName)

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SerologyToAllelesMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SerologyToAllelesMetadataService.cs
@@ -1,5 +1,6 @@
 ﻿using Atlas.Common.Caching;
 using Atlas.Common.GeneticData.Hla.Services;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.Metadata;
 using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
@@ -19,8 +20,8 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             Locus locus, string serologyName, string hlaNomenclatureVersion);
     }
 
-    internal class SerologyToAllelesMetadataService : 
-        SearchRelatedMetadataServiceBase<ISerologyToAllelesMetadata>, 
+    internal class SerologyToAllelesMetadataService :
+        SearchRelatedMetadataServiceBase<ISerologyToAllelesMetadata>,
         ISerologyToAllelesMetadataService
     {
         private const string CacheKey = nameof(SerologyToAllelesMetadataService);
@@ -43,12 +44,14 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
                 macDictionary,
                 alleleGroupExpander,
                 CacheKey,
-                cacheProvider, 
-                options)
+                cacheProvider,
+                options
+            )
         {
         }
 
-        public async Task<IEnumerable<SerologyToAlleleMappingSummary>> GetSerologyToAlleleMappings(Locus locus, string serologyName, string hlaNomenclatureVersion)
+        public async Task<IEnumerable<SerologyToAlleleMappingSummary>> GetSerologyToAlleleMappings(Locus locus, string serologyName,
+            string hlaNomenclatureVersion)
         {
             var metadata = await GetHlaMetadata(locus, serologyName, hlaNomenclatureVersion);
             return metadata.SerologyToAlleleMappings;
@@ -66,6 +69,13 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             List<ISerologyToAllelesMetadata> metadata)
         {
             // should only be 1 metadata row per valid serology typing
+            // No rows is a name with no data, and has to say so: GetMetadata no longer re-labels the Single()
+            // failure as one. See HlaScoringMetadataService.ConsolidateHlaMetadata.
+            if (metadata.Count == 0)
+            {
+                throw new InvalidHlaException(locus, lookupName);
+            }
+
             return metadata.Single();
         }
     }

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SmallGGroupMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SmallGGroupMetadataService.cs
@@ -1,5 +1,6 @@
 ﻿using Atlas.Common.Caching;
 using Atlas.Common.GeneticData.Hla.Services;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.InternalModels.Metadata;
 using Atlas.HlaMetadataDictionary.InternalModels.MetadataTableRows;
 using Atlas.HlaMetadataDictionary.Repositories.MetadataRepositories;
@@ -102,6 +103,13 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             string lookupName,
             List<ISmallGGroupsMetadata> metadata)
         {
+            // No rows is a name with no data, and has to say so: GetMetadata no longer re-labels the Single()
+            // failure as one. See HlaScoringMetadataService.ConsolidateHlaMetadata.
+            if (metadata.Count == 0)
+            {
+                throw new InvalidHlaException(locus, lookupName);
+            }
+
             var typingMethod = metadata.Select(m => m.TypingMethod).Distinct().Single();
 
             var groups = metadata

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SmallGGroupMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SmallGGroupMetadataService.cs
@@ -19,6 +19,11 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         /// </summary>
         Task<IEnumerable<string>> GetSmallGGroups(Locus locus, string hlaName, string hlaNomenclatureVersion);
 
+        /// <summary>
+        /// <see cref="GetSmallGGroups"/> for a caller that treats an unknown HLA name as an answer
+        /// </summary>
+        Task<(bool WasFound, IEnumerable<string> SmallGGroups)> TryGetSmallGGroups(Locus locus, string hlaName, string hlaNomenclatureVersion);
+
         Task<IDictionary<Locus, ISet<string>>> GetAllSmallGGroups(string hlaNomenclatureVersion);
     }
 
@@ -63,6 +68,22 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             }
             var metadata = await GetHlaMetadata(locus, hlaName, hlaNomenclatureVersion);
             return metadata.SmallGGroups;
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, IEnumerable<string> SmallGGroups)> TryGetSmallGGroups(
+            Locus locus,
+            string hlaName,
+            string hlaNomenclatureVersion)
+        {
+            if (hlaName == NewAllele)
+            {
+                return (true, new List<string>());
+            }
+
+            var (wasFound, metadata) = await TryGetHlaMetadata(locus, hlaName, hlaNomenclatureVersion);
+
+            return (wasFound, wasFound ? metadata.SmallGGroups : null);
         }
 
         public async Task<IDictionary<Locus, ISet<string>>> GetAllSmallGGroups(string hlaNomenclatureVersion)

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SmallGGroupToPGroupMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/SmallGGroupToPGroupMetadataService.cs
@@ -15,6 +15,16 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         /// reliant on the fact that each small g Group will only have 0 or 1 corresponding P Groups.
         /// </summary>
         Task<string> ConvertSmallGGroupToPGroup(Locus locus, string smallGGroupLookupName, string hlaNomenclatureVersion);
+
+        /// <summary>
+        /// <see cref="ConvertSmallGGroupToPGroup"/> for a caller that treats an unrecognised small g group as an answer
+        /// rather than an error
+        /// </summary>
+        /// <returns>
+        /// <c>(false, null)</c> where the small g group is not in the data. <c>(true, null)</c> is distinct and
+        /// legitimate: a small g group of null-expressing alleles is recognised and has no P group.
+        /// </returns>
+        Task<(bool WasFound, string PGroup)> TryConvertSmallGGroupToPGroup(Locus locus, string smallGGroupLookupName, string hlaNomenclatureVersion);
     }
 
     internal class SmallGGroupToPGroupMetadataService : MetadataServiceBase<string>, ISmallGGroupToPGroupMetadataService
@@ -56,6 +66,20 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
             }
 
             return await GetMetadata(locus, smallGGroupLookupName, hlaNomenclatureVersion);
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, string PGroup)> TryConvertSmallGGroupToPGroup(
+            Locus locus,
+            string smallGGroupLookupName,
+            string hlaNomenclatureVersion)
+        {
+            if (smallGGroupLookupName == null)
+            {
+                return (true, null);
+            }
+
+            return await TryGetMetadata(locus, smallGGroupLookupName, hlaNomenclatureVersion);
         }
     }
 }

--- a/Atlas.HlaMetadataDictionary/Services/HlaConversion/HlaConverter.cs
+++ b/Atlas.HlaMetadataDictionary/Services/HlaConversion/HlaConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Atlas.Common.Public.Models.GeneticData;
 using Atlas.Common.Utils.Extensions;
+using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.Metadata.ScoringMetadata;
 using Atlas.HlaMetadataDictionary.Services.DataRetrieval;
@@ -13,6 +14,15 @@ namespace Atlas.HlaMetadataDictionary.Services.HlaConversion
     internal interface IHlaConverter
     {
         Task<IReadOnlyCollection<string>> ConvertHla(Locus locus, string hlaName, HlaConversionBehaviour conversionBehaviour);
+
+        /// <summary>
+        /// <see cref="ConvertHla"/> for a caller that treats an unknown HLA name as an answer. See
+        /// <c><seealso cref="MetadataServiceBase{T}.TryGetMetadata"/>MetadataServiceBase.TryGetMetadata</c> for why an infrastructure fault still throws.
+        /// </summary>
+        Task<(bool WasFound, IReadOnlyCollection<string> Hla)> TryConvertHla(
+            Locus locus,
+            string hlaName,
+            HlaConversionBehaviour conversionBehaviour);
     }
 
     internal class HlaConverter : IHlaConverter
@@ -64,6 +74,62 @@ namespace Atlas.HlaMetadataDictionary.Services.HlaConversion
                 default:
                     throw new ArgumentOutOfRangeException(nameof(conversionBehaviour), conversionBehaviour, null);
             }
+        }
+
+        /// <inheritdoc />
+        public async Task<(bool WasFound, IReadOnlyCollection<string> Hla)> TryConvertHla(
+            Locus locus,
+            string hlaName,
+            HlaConversionBehaviour conversionBehaviour)
+        {
+            if (hlaName.IsNullOrEmpty() || conversionBehaviour == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            switch (conversionBehaviour.TargetHlaCategory)
+            {
+                case TargetHlaCategory.GGroup:
+                {
+                    var (wasFound, scoringInfo) = await TryGetHlaScoringInfo(locus, hlaName, conversionBehaviour.HlaNomenclatureVersion);
+                    return (wasFound, wasFound ? scoringInfo.MatchingGGroups.ToList() : null);
+                }
+                case TargetHlaCategory.PGroup:
+                {
+                    var (wasFound, scoringInfo) = await TryGetHlaScoringInfo(locus, hlaName, conversionBehaviour.HlaNomenclatureVersion);
+                    return (wasFound, wasFound ? scoringInfo.MatchingPGroups.ToList() : null);
+                }
+                case TargetHlaCategory.SmallGGroup:
+                {
+                    var (wasFound, smallGGroups) = await smallGGroupMetadataService.TryGetSmallGGroups(
+                        locus, hlaName, conversionBehaviour.HlaNomenclatureVersion);
+                    return (wasFound, wasFound ? smallGGroups.ToList() : null);
+                }
+                default:
+                    try
+                    {
+                        return (true, await ConvertHla(locus, hlaName, conversionBehaviour));
+                    }
+                    catch (HlaMetadataDictionaryException)
+                    {
+                        return (false, null);
+                    }
+            }
+        }
+
+        private async Task<(bool WasFound, IHlaScoringInfo ScoringInfo)> TryGetHlaScoringInfo(
+            Locus locus,
+            string hlaName,
+            string hlaNomenclatureVersion)
+        {
+            if (hlaName == NewAllele)
+            {
+                return (true, new NewAlleleScoringInfo());
+            }
+
+            var (wasFound, metadata) = await scoringMetadataService.TryGetHlaMetadata(locus, hlaName, hlaNomenclatureVersion);
+
+            return (wasFound, wasFound ? metadata.HlaScoringInfo : null);
         }
 
         private async Task<IHlaScoringInfo> GetHlaScoringInfo(Locus locus, string hlaName, string hlaNomenclatureVersion)

--- a/Atlas.HlaMetadataDictionary/Services/HlaConversion/HlaConverter.cs
+++ b/Atlas.HlaMetadataDictionary/Services/HlaConversion/HlaConverter.cs
@@ -16,8 +16,8 @@ namespace Atlas.HlaMetadataDictionary.Services.HlaConversion
         Task<IReadOnlyCollection<string>> ConvertHla(Locus locus, string hlaName, HlaConversionBehaviour conversionBehaviour);
 
         /// <summary>
-        /// <see cref="ConvertHla"/> for a caller that treats an unknown HLA name as an answer. See
-        /// <c><seealso cref="MetadataServiceBase{T}.TryGetMetadata"/>MetadataServiceBase.TryGetMetadata</c> for why an infrastructure fault still throws.
+        /// <see cref="ConvertHla"/> for a caller that treats an unknown HLA name as an answer.
+        /// See <see cref="MetadataServiceBase{T}.TryGetMetadata"/> for why an infrastructure fault still throws.
         /// </summary>
         Task<(bool WasFound, IReadOnlyCollection<string> Hla)> TryConvertHla(
             Locus locus,

--- a/Atlas.HlaMetadataDictionary/Services/HlaConversion/HlaNameToTwoFieldAlleleConverter.cs
+++ b/Atlas.HlaMetadataDictionary/Services/HlaConversion/HlaNameToTwoFieldAlleleConverter.cs
@@ -7,7 +7,9 @@ using Atlas.Common.GeneticData.Hla.Models;
 using Atlas.Common.GeneticData.Hla.Services;
 using Atlas.Common.Public.Models.GeneticData;
 using Atlas.HlaMetadataDictionary.ExternalInterface.Models.HLATypings;
+using Atlas.HlaMetadataDictionary.InternalExceptions;
 using Atlas.HlaMetadataDictionary.Services.DataRetrieval;
+using Atlas.MultipleAlleleCodeDictionary;
 using Atlas.MultipleAlleleCodeDictionary.ExternalInterface;
 
 namespace Atlas.HlaMetadataDictionary.Services.HlaConversion
@@ -49,7 +51,10 @@ namespace Atlas.HlaMetadataDictionary.Services.HlaConversion
             ExpressionSuffixBehaviour behaviour,
             string hlaNomenclatureVersion)
         {
-            var inputCategory = hlaCategorisationService.GetHlaTypingCategory(hlaName);
+            // A name whose category cannot be determined has no data, and TryConvertHla promises to report that as
+            // `false` rather than throw. The categoriser says it with an AtlasHttpException, which would escape as
+            // though it were an infrastructure fault.
+            var inputCategory = hlaCategorisationService.GetCategoryOrThrowInvalidHla(locus, hlaName);
 
             switch (inputCategory)
             {
@@ -66,18 +71,31 @@ namespace Atlas.HlaMetadataDictionary.Services.HlaConversion
                     var allelesFromAlleleString = alleleNamesExtractor.GetAlleleNamesFromAlleleString(hlaName);
                     return GetTwoFieldAlleleNames(locus, allelesFromAlleleString, behaviour);
                 case HlaTypingCategory.NmdpCode:
-                    var allelesForNmdpCode = await macDictionary.GetHlaFromMac(hlaName);
-                    return GetTwoFieldAlleleNames(locus, allelesForNmdpCode, behaviour);
+                    // See MacLookup.GetAlleleLookupNames: the MAC dictionary reports "not in the store" in its own
+                    // vocabulary, and only a genuine storage failure should leave here as itself.
+                    try
+                    {
+                        var allelesForNmdpCode = await macDictionary.GetHlaFromMac(hlaName);
+                        return GetTwoFieldAlleleNames(locus, allelesForNmdpCode, behaviour);
+                    }
+                    catch (Exception e) when (e is MacNotFoundException or ArgumentException)
+                    {
+                        throw new InvalidHlaException(locus, hlaName);
+                    }
                 case HlaTypingCategory.XxCode:
                     throw new NotImplementedException("XX Code to Two Field Conversion has not been implemented.");
                 case HlaTypingCategory.Serology:
                     throw new NotImplementedException("Serology to Two Field Conversion has not been implemented.");
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    // A category with no two-field conversion is a name this converter cannot answer for, not an
+                    // infrastructure fault. NotImplementedException above is deliberately left alone: those two are
+                    // unbuilt features, not missing data.
+                    throw new InvalidHlaException(locus, hlaName);
             }
         }
 
-        private static IReadOnlyCollection<string> GetTwoFieldAlleleNames(Locus locus, IEnumerable<string> alleleNames, ExpressionSuffixBehaviour behaviour)
+        private static IReadOnlyCollection<string> GetTwoFieldAlleleNames(Locus locus, IEnumerable<string> alleleNames,
+            ExpressionSuffixBehaviour behaviour)
         {
             return alleleNames
                 .Select(allele => GetTwoFieldAlleleName(locus, allele, behaviour))

--- a/Atlas.MatchPrediction.Test/Services/GroupToPGroupConverterTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/GroupToPGroupConverterTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Atlas.Common.ApplicationInsights;
+using Atlas.Common.Public.Models.GeneticData;
+using Atlas.Common.Test.SharedTestHelpers.Builders;
+using Atlas.HlaMetadataDictionary.ExternalInterface;
+using Atlas.MatchPrediction.ApplicationInsights;
+using Atlas.MatchPrediction.Services.HlaConversion;
+using AutoFixture;
+using AutoFixture.Dsl;
+using AwesomeAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Atlas.MatchPrediction.Test.Services;
+
+/// <summary>
+/// The two <see cref="HlaConverterBase"/> implementations that turn a pooled haplotype's group name into a P group.
+///
+/// <para>
+/// The outcome to pin is the one a bare value cannot express: a group of null-expressing alleles <b>is</b> in the data
+/// and has no P group. Reporting that as a failed conversion would log an error, retry the lookup at the other
+/// nomenclature version, and hand the caller nothing where it expects a null.
+/// </para>
+/// </summary>
+[TestFixture]
+internal class GroupToPGroupConverterTests
+{
+    private const Locus DefaultLocus = Locus.A;
+
+    private IHlaMetadataDictionary hmd;
+    private IMatchPredictionLogger<MatchProbabilityLoggingContext> logger;
+    private IPostprocessComposer<HlaConverterInput> inputBuilder;
+    private Fixture fixture;
+
+    private IHlaConverter gGroupConverter;
+    private IHlaConverter smallGGroupConverter;
+
+    [SetUp]
+    public void SetUp()
+    {
+        fixture = new Fixture();
+        logger = Substitute.For<IMatchPredictionLogger<MatchProbabilityLoggingContext>>();
+        hmd = Substitute.For<IHlaMetadataDictionary>();
+
+        gGroupConverter = new GGroupToPGroupConverter(logger);
+        smallGGroupConverter = new SmallGGroupToPGroupConverter(logger);
+
+        // No matching-algorithm dictionary, so a failed conversion is not retried at a second nomenclature version:
+        // these tests are about what one lookup reports. HlaConverterTests covers the retry.
+        inputBuilder = FixtureBuilder.For<HlaConverterInput>()
+            .With(x => x.HfSetHmd, hmd)
+            .With(x => x.MatchingAlgorithmHmd, (IHlaMetadataDictionary)null);
+    }
+
+    [Test]
+    public async Task GGroupToPGroup_WhenTheGroupHasAPGroup_ReturnsIt()
+    {
+        var gGroup = fixture.Create<string>();
+        var pGroup = fixture.Create<string>();
+        hmd.TryConvertGGroupToPGroup(DefaultLocus, gGroup).Returns((true, pGroup));
+
+        var result = await gGroupConverter.ConvertHlaWithLoggingAndRetryOnFailure(inputBuilder.Build(), DefaultLocus, gGroup);
+
+        result.Should().Equal(pGroup);
+        ShouldNotHaveLoggedAFailure();
+    }
+
+    [Test]
+    public async Task GGroupToPGroup_WhenTheGroupIsFoundAndHasNoPGroup_ReturnsASingleNullAndLogsNothing()
+    {
+        var gGroup = fixture.Create<string>();
+        hmd.TryConvertGGroupToPGroup(DefaultLocus, gGroup).Returns((true, (string) null));
+
+        var result = await gGroupConverter.ConvertHlaWithLoggingAndRetryOnFailure(inputBuilder.Build(), DefaultLocus, gGroup);
+
+        result.Should().ContainSingle().Which.Should().BeNull();
+        ShouldNotHaveLoggedAFailure();
+    }
+
+    [Test]
+    public async Task GGroupToPGroup_WhenTheGroupHasNoData_ReturnsNothingAndLogsTheFailure()
+    {
+        var gGroup = fixture.Create<string>();
+        hmd.TryConvertGGroupToPGroup(DefaultLocus, gGroup).Returns((false, (string) null));
+
+        var result = await gGroupConverter.ConvertHlaWithLoggingAndRetryOnFailure(inputBuilder.Build(), DefaultLocus, gGroup);
+
+        result.Should().BeEmpty();
+        ShouldHaveLoggedOneFailure();
+    }
+
+    [Test]
+    public async Task SmallGGroupToPGroup_WhenTheGroupHasAPGroup_ReturnsIt()
+    {
+        var smallGGroup = fixture.Create<string>();
+        var pGroup = fixture.Create<string>();
+        hmd.TryConvertSmallGGroupToPGroup(DefaultLocus, smallGGroup).Returns((true, pGroup));
+
+        var result = await smallGGroupConverter.ConvertHlaWithLoggingAndRetryOnFailure(inputBuilder.Build(), DefaultLocus, smallGGroup);
+
+        result.Should().Equal(pGroup);
+        ShouldNotHaveLoggedAFailure();
+    }
+
+    [Test]
+    public async Task SmallGGroupToPGroup_WhenTheGroupIsFoundAndHasNoPGroup_ReturnsASingleNullAndLogsNothing()
+    {
+        var smallGGroup = fixture.Create<string>();
+        hmd.TryConvertSmallGGroupToPGroup(DefaultLocus, smallGGroup).Returns((true, (string) null));
+
+        var result = await smallGGroupConverter.ConvertHlaWithLoggingAndRetryOnFailure(inputBuilder.Build(), DefaultLocus, smallGGroup);
+
+        result.Should().ContainSingle().Which.Should().BeNull();
+        ShouldNotHaveLoggedAFailure();
+    }
+
+    [Test]
+    public async Task SmallGGroupToPGroup_WhenTheGroupHasNoData_ReturnsNothingAndLogsTheFailure()
+    {
+        var smallGGroup = fixture.Create<string>();
+        hmd.TryConvertSmallGGroupToPGroup(DefaultLocus, smallGGroup).Returns((false, (string) null));
+
+        var result = await smallGGroupConverter.ConvertHlaWithLoggingAndRetryOnFailure(inputBuilder.Build(), DefaultLocus, smallGGroup);
+
+        result.Should().BeEmpty();
+        ShouldHaveLoggedOneFailure();
+    }
+
+    private void ShouldHaveLoggedOneFailure() => logger.Received(1).SendEvent(
+        Arg.Any<string>(), Arg.Any<LogLevel>(), Arg.Any<Dictionary<string, string>>(), Arg.Any<Dictionary<string, double>>());
+
+    private void ShouldNotHaveLoggedAFailure() => logger.DidNotReceiveWithAnyArgs().SendEvent(
+        Arg.Any<string>(), Arg.Any<LogLevel>(), Arg.Any<Dictionary<string, string>>(), Arg.Any<Dictionary<string, double>>());
+}

--- a/Atlas.MatchPrediction.Test/Services/HlaConverterTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/HlaConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.Public.Models.GeneticData;
@@ -46,14 +47,21 @@ internal class HlaConverterTests
 
         hfSetHmd = Substitute.For<IHlaMetadataDictionary>();
         hfSetHmd.HlaNomenclatureVersion.Returns(HfSetHlaVersion);
-        hfSetHmd.ConvertHla(default, default, default).ReturnsForAnyArgs(HfSetHmdResult);
+        hfSetHmd.TryConvertHla(default, default, default).ReturnsForAnyArgs((true, HfSetHmdResult));
 
         matchingHmd = Substitute.For<IHlaMetadataDictionary>();
         matchingHmd.HlaNomenclatureVersion.Returns(MatchingAlgorithmHlaVersion);
-        matchingHmd.ConvertHla(default, default, default).ReturnsForAnyArgs(MatchingHmdResult);
+        matchingHmd.TryConvertHla(default, default, default).ReturnsForAnyArgs((true, MatchingHmdResult));
 
         inputBuilder = FixtureBuilder.For<HlaConverterInput>();
     }
+
+    /// <summary>
+    /// A name with no data is <c>(false, null)</c>, not an exception. Every "arrange lookup failure"
+    /// below used to be <c>ThrowsForAnyArgs(new HlaMetadataDictionaryException(...))</c>; the assertions are unchanged.
+    /// </summary>
+    private static void ArrangeLookupFailure(IHlaMetadataDictionary hmd) =>
+        hmd.TryConvertHla(default, default, default).ReturnsForAnyArgs((false, (IReadOnlyCollection<string>)null));
 
     #region DoesNotTryLookupUsingMatchingAlgorithmHmd tests
 
@@ -105,7 +113,7 @@ internal class HlaConverterTests
 
         await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
 
-        await hfSetHmd.Received().ConvertHla(DefaultLocus, HlaName, target);
+        await hfSetHmd.Received().TryConvertHla(DefaultLocus, HlaName, target);
     }
 
     [Test]
@@ -150,7 +158,7 @@ internal class HlaConverterTests
 
         await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
 
-        await matchingHmd.DidNotReceiveWithAnyArgs().ConvertHla(default, default, default);
+        await matchingHmd.DidNotReceiveWithAnyArgs().TryConvertHla(default, default, default);
     }
 
     [Test]
@@ -168,17 +176,14 @@ internal class HlaConverterTests
 
         await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
 
-        await matchingHmd.DidNotReceiveWithAnyArgs().ConvertHla(default, default, default);
+        await matchingHmd.DidNotReceiveWithAnyArgs().TryConvertHla(default, default, default);
     }
 
     [Test]
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_FirstLookupFails_LogsFailure(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
         var input = inputBuilder
             .With(x => x.HfSetHmd, hfSetHmd)
@@ -195,10 +200,7 @@ internal class HlaConverterTests
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_FirstLookupFails_AndRetryEnabled_RetriesLookupUsingMatchingHmd(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
         var input = inputBuilder
             .With(x => x.HfSetHmd, hfSetHmd)
@@ -208,17 +210,14 @@ internal class HlaConverterTests
 
         await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
 
-        await matchingHmd.Received().ConvertHla(DefaultLocus, HlaName, target);
+        await matchingHmd.Received().TryConvertHla(DefaultLocus, HlaName, target);
     }
 
     [Test]
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_FirstLookupFails_AndRetryEnabled_ReturnsResults(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
         var input = inputBuilder
             .With(x => x.HfSetHmd, hfSetHmd)
@@ -235,10 +234,7 @@ internal class HlaConverterTests
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_FirstLookupFails_AndRetryDisabled_DoesNotRetryLookup(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
         // disables retry
         matchingHmd.HlaNomenclatureVersion.Returns(HfSetHlaVersion);
@@ -251,17 +247,14 @@ internal class HlaConverterTests
 
         await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
 
-        await matchingHmd.DidNotReceiveWithAnyArgs().ConvertHla(default, default, default);
+        await matchingHmd.DidNotReceiveWithAnyArgs().TryConvertHla(default, default, default);
     }
 
     [Test]
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_FirstLookupFails_AndRetryDisabled_ReturnsEmptyCollection(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
         // disables retry
         matchingHmd.HlaNomenclatureVersion.Returns(HfSetHlaVersion);
@@ -281,15 +274,9 @@ internal class HlaConverterTests
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_SecondLookupFails_LogsFirstAndSecondFailure(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
-        // arrange second lookup failure
-        matchingHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(matchingHmd);
 
         var input = inputBuilder
             .With(x => x.HfSetHmd, hfSetHmd)
@@ -306,15 +293,9 @@ internal class HlaConverterTests
     public async Task ConvertHlaWithLoggingAndRetryOnFailure_SecondLookupFails_ReturnsEmptyCollection(
         [Values] TargetHlaCategory target)
     {
-        // arrange first lookup failure
-        hfSetHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(hfSetHmd);
 
-        // arrange second lookup failure
-        matchingHmd
-            .ConvertHla(default, default, default)
-            .ThrowsForAnyArgs(new HlaMetadataDictionaryException(default, default, default));
+        ArrangeLookupFailure(matchingHmd);
 
         var input = inputBuilder
             .With(x => x.HfSetHmd, hfSetHmd)
@@ -325,6 +306,33 @@ internal class HlaConverterTests
         var results = await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
 
         results.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ConvertHlaWithLoggingAndRetryOnFailure_WhenTheLookupFaults_PropagatesInsteadOfReportingNoData(
+        [Values] TargetHlaCategory target)
+    {
+        // A failed storage request is not a missing name, and this is the case that used to be
+        // indistinguishable: both arrived as HlaMetadataDictionaryException, both were swallowed into an empty result,
+        // so a transient blip silently read as "this HLA does not exist" and match prediction ran on an incomplete
+        // expansion with nothing logged as an error. Only a name with no data returns (false, null) now; anything else
+        // escapes, and the caller can tell them apart for the first time.
+        hfSetHmd.TryConvertHla(default, default, default)
+            .ThrowsForAnyArgs(new TimeoutException("storage is having a moment"));
+
+        var input = inputBuilder
+            .With(x => x.HfSetHmd, hfSetHmd)
+            .With(x => x.MatchingAlgorithmHmd, matchingHmd)
+            .With(x => x.TargetHlaCategory, target)
+            .Build();
+
+        var convert = async () => await converter.ConvertHlaWithLoggingAndRetryOnFailure(input, DefaultLocus, HlaName);
+
+        await convert.Should().ThrowAsync<TimeoutException>();
+
+        // And it is not reported as a conversion failure, because it is not one.
+        logger.DidNotReceiveWithAnyArgs().SendEvent(
+            Arg.Any<string>(), Arg.Any<LogLevel>(), Arg.Any<Dictionary<string, string>>(), Arg.Any<Dictionary<string, double>>());
     }
 
     #endregion

--- a/Atlas.MatchPrediction/Services/HlaConversion/GGroupToPGroupConverter.cs
+++ b/Atlas.MatchPrediction/Services/HlaConversion/GGroupToPGroupConverter.cs
@@ -19,10 +19,16 @@ namespace Atlas.MatchPrediction.Services.HlaConversion
         {
         }
 
-        protected override async Task<IEnumerable<string>> ConvertHla(
+        protected override async Task<(bool WasFound, IEnumerable<string> ConvertedHla)> TryConvert(
             TargetHlaCategory? targetHlaCategory, Locus locus, string hla, IHlaMetadataDictionary hmd)
         {
-            return new[] { await hmd.ConvertGGroupToPGroup(locus, hla) };
+            var (wasFound, pGroup) = await hmd.TryConvertGGroupToPGroup(locus, hla);
+
+            // The single-element array is the shipped shape, and it is kept even when the P group is null: a G group of
+            // null-expressing alleles is FOUND and has no P group. Staying FOUND is what matters - a not-found is
+            // logged as a conversion failure and retried at the other nomenclature version - and the null then reaches
+            // the null-allele rule through GenotypeConverter's SingleOrDefault().
+            return (wasFound, wasFound ? new[] { pGroup } : null);
         }
     }
 }

--- a/Atlas.MatchPrediction/Services/HlaConversion/HlaConverterBase.cs
+++ b/Atlas.MatchPrediction/Services/HlaConversion/HlaConverterBase.cs
@@ -1,6 +1,5 @@
 ﻿using Atlas.HlaMetadataDictionary.ExternalInterface;
 using Atlas.Common.Public.Models.GeneticData;
-using Atlas.HlaMetadataDictionary.ExternalInterface.Exceptions;
 using Atlas.MatchPrediction.ApplicationInsights;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -67,29 +66,44 @@ namespace Atlas.MatchPrediction.Services.HlaConversion
 
             async Task<(bool WasSuccessful, IEnumerable<string> ConvertedHla)> TryConvertHla(IHlaMetadataDictionary hmd)
             {
-                try
+                // No try/catch: the dictionary now answers "this name has no data" as a value, so
+                // the common case costs no throw. What a `catch` would still be needed for is an infrastructure fault, and
+                // those deliberately propagate now rather than being swallowed as a failed conversion: reading a
+                // storage blip as "this HLA does not exist" would predict from an incomplete expansion, silently.
+                var (wasFound, convertedHla) = await TryConvert(input.TargetHlaCategory, locus, hla, hmd);
+
+                if (wasFound)
                 {
-                    var convertedHla = await ConvertHla(input.TargetHlaCategory, locus, hla, hmd);
                     return (true, convertedHla);
                 }
-                catch (HlaMetadataDictionaryException exception)
-                {
-                    logger.SendEvent("HLA Conversion Failed", LogLevel.Warn, new Dictionary<string, string>
-                    {
-                        { "Locus", locus.ToString() },
-                        { "Hla", hla },
-                        { "HlaNomenclatureVersion", hmd.HlaNomenclatureVersion },
-                        { nameof(TargetHlaCategory), input.TargetHlaCategory.ToString() },
-                        { "Stage of Failure", input.StageToLog },
-                        { nameof(HlaMetadataDictionaryException), exception.ToString() }
-                    });
 
-                    return (false, new List<string>());
-                }
+                LogConversionFailure(hmd);
+
+                return (false, new List<string>());
+            }
+
+            void LogConversionFailure(IHlaMetadataDictionary hmd)
+            {
+                // These five dimensions are the whole diagnostic: which name, at which locus, at which
+                // nomenclature version, converting to what, during which stage. `exception.ToString()` used to be a
+                // sixth - a full async stack, multiple kilobytes - and it added nothing they do not already say,
+                // because the exception's own message was "Failed to lookup '<Hla>' at locus <Locus>".
+                //
+                // It was not free. This is not an error path in production: a 248-donor run reached it 11,538 times,
+                // and those strings were possibly a larger cost than the throws they accompanied. There is no longer
+                // an exception here to serialise in any case - see TryConvert below.
+                logger.SendEvent("HLA Conversion Failed", LogLevel.Warn, new Dictionary<string, string>
+                {
+                    { "Locus", locus.ToString() },
+                    { "Hla", hla },
+                    { "HlaNomenclatureVersion", hmd.HlaNomenclatureVersion },
+                    { nameof(TargetHlaCategory), input.TargetHlaCategory.ToString() },
+                    { "Stage of Failure", input.StageToLog }
+                });
             }
         }
 
-        protected abstract Task<IEnumerable<string>> ConvertHla(
+        protected abstract Task<(bool WasFound, IEnumerable<string> ConvertedHla)> TryConvert(
             TargetHlaCategory? targetHlaCategory, Locus locus, string hla, IHlaMetadataDictionary hmd);
     }
 }

--- a/Atlas.MatchPrediction/Services/HlaConversion/HlaToTargetCatgeoryConverter.cs
+++ b/Atlas.MatchPrediction/Services/HlaConversion/HlaToTargetCatgeoryConverter.cs
@@ -20,7 +20,7 @@ namespace Atlas.MatchPrediction.Services.HlaConversion
         {
         }
 
-        protected override async Task<IEnumerable<string>> ConvertHla(
+        protected override async Task<(bool WasFound, IEnumerable<string> ConvertedHla)> TryConvert(
             TargetHlaCategory? targetHlaCategory, Locus locus, string hla, IHlaMetadataDictionary hmd)
         {
             if (targetHlaCategory == null)
@@ -28,7 +28,7 @@ namespace Atlas.MatchPrediction.Services.HlaConversion
                 throw new ArgumentNullException(nameof(targetHlaCategory));
             }
 
-            return await hmd.ConvertHla(locus, hla, targetHlaCategory.Value);
+            return await hmd.TryConvertHla(locus, hla, targetHlaCategory.Value);
         }
     }
 }

--- a/Atlas.MatchPrediction/Services/HlaConversion/SmallGGroupToPGroupConverter.cs
+++ b/Atlas.MatchPrediction/Services/HlaConversion/SmallGGroupToPGroupConverter.cs
@@ -19,10 +19,14 @@ namespace Atlas.MatchPrediction.Services.HlaConversion
         {
         }
 
-        protected override async Task<IEnumerable<string>> ConvertHla(
+        protected override async Task<(bool WasFound, IEnumerable<string> ConvertedHla)> TryConvert(
             TargetHlaCategory? targetHlaCategory, Locus locus, string hla, IHlaMetadataDictionary hmd)
         {
-            return new[] { await hmd.ConvertSmallGGroupToPGroup(locus, hla) };
+            var (wasFound, pGroup) = await hmd.TryConvertSmallGGroupToPGroup(locus, hla);
+
+            // As in GGroupToPGroupConverter: found-with-no-P-group is a real outcome for a group of null-expressing
+            // alleles, and must stay FOUND rather than be logged as a failure and retried at the other version.
+            return (wasFound, wasFound ? new[] { pGroup } : null);
         }
     }
 }

--- a/Atlas.MatchingAlgorithm.Test/Services/Donors/DonorHlaExpanderTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Services/Donors/DonorHlaExpanderTests.cs
@@ -143,25 +143,32 @@ namespace Atlas.MatchingAlgorithm.Test.Services.Donors
             });
         }
 
+        /// <summary>
+        /// Was <c>ExpandDonorHlaBatchAsync_UnanticipatedExpansionFailure_ThrowsException</c>, and asserted the
+        /// opposite. It passed for the wrong reason: nothing was unanticipated here, because
+        /// <c>MetadataServiceBase.GetMetadata</c> re-labelled every failure as an
+        /// <c>HlaMetadataDictionaryException</c> before it could reach the batch processor. Now that it does not, the
+        /// per-donor policy has to be stated at the call site, and this asserts it.
+        /// </summary>
         [Test]
-        public void ExpandDonorHlaBatchAsync_UnanticipatedExpansionFailure_ThrowsException()
+        public async Task ExpandDonorHlaBatchAsync_ExpansionFailsForAReasonOtherThanTheHla_StillFailsOnlyThatDonor()
         {
-            hlaMetadataDictionary
-                .GetLocusHlaMatchingMetadata(Locus.A, Arg.Any<LocusInfo<string>>())
-                .Throws(new Exception("error"));
+            const int failedDonorId = 123;
+            const int successfulDonorId = 456;
 
-            Assert.ThrowsAsync<Exception>(async () =>
+            hlaMetadataDictionary
+                .GetLocusHlaMatchingMetadata(Arg.Any<Locus>(), Arg.Is<LocusInfo<string>>(h => h.Position1 == "faulting-hla"))
+                .Throws(new TimeoutException("the storage request timed out"));
+
+            var result = await donorHlaExpander.ExpandDonorHlaBatchAsync(
+                new List<DonorInfo>
                 {
-                    await donorHlaExpander.ExpandDonorHlaBatchAsync(new List<DonorInfo>
-                    {
-                        new DonorInfo
-                        {
-                            HlaNames = new PhenotypeInfo<string>("hla")
-                        }
-                    },
-                        "event-name");
-                }
-            );
+                    new DonorInfo {DonorId = failedDonorId, HlaNames = new PhenotypeInfo<string>("faulting-hla")},
+                    new DonorInfo {DonorId = successfulDonorId, HlaNames = new PhenotypeInfo<string>("hla")}
+                },
+                "event-name");
+
+            result.FailedDonors.Should().OnlyContain(d => d.AtlasDonorId == failedDonorId);
         }
     }
 }

--- a/Atlas.MatchingAlgorithm/Services/Donors/DonorHlaExpander.cs
+++ b/Atlas.MatchingAlgorithm/Services/Donors/DonorHlaExpander.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.GeneticData;
@@ -37,11 +38,20 @@ namespace Atlas.MatchingAlgorithm.Services.Donors
             this.hlaMetadataDictionary = hlaMetadataDictionary;
         }
 
+        /// <remarks>
+        /// <c>Exception</c>, not <see cref="HlaMetadataDictionaryException"/>, and deliberately: one donor failing must
+        /// fail only that donor, whatever the reason. That was already the behaviour, but by accident -
+        /// <c>MetadataServiceBase.GetMetadata</c> re-labelled every failure as an
+        /// <see cref="HlaMetadataDictionaryException"/>, so catching that type caught everything. It no longer does,
+        /// which would have made an infrastructure fault on one donor end the whole batch, and with it a data refresh
+        /// that cannot resume. Stating the policy directly keeps it where it belongs - in the caller that decides what
+        /// a failed donor is - rather than depending on how far up the dictionary happens to launder its exceptions.
+        /// </remarks>
         public async Task<DonorBatchProcessingResult<DonorInfoWithExpandedHla>> ExpandDonorHlaBatchAsync(
             IEnumerable<DonorInfo> donorInfos,
             string failureEventName)
         {
-            return await ProcessBatchAsyncWithAnticipatedExceptions<HlaMetadataDictionaryException>(
+            return await ProcessBatchAsyncWithAnticipatedExceptions<Exception>(
                 donorInfos,
                 async d => await ExpandDonorHlaAsync(d),
                 d => d.ToFailedDonorInfo(),

--- a/Atlas.MultipleAlleleCodeDictionary/MacNotFoundException.cs
+++ b/Atlas.MultipleAlleleCodeDictionary/MacNotFoundException.cs
@@ -2,7 +2,13 @@ using System;
 
 namespace Atlas.MultipleAlleleCodeDictionary
 {
-    internal class MacNotFoundException : Exception
+    /// <summary>
+    /// Public because it is part of this dictionary's contract, not an implementation detail: it is how
+    /// <see cref="ExternalInterface.IMacDictionary.GetHlaFromMac(string)"/> says a MAC is not in the store, and a
+    /// caller has to be able to tell that apart from a failed storage request. <c>MacLookup</c> in the HLA Metadata
+    /// Dictionary does exactly that.
+    /// </summary>
+    public class MacNotFoundException : Exception
     {
         public MacNotFoundException(string mac) : base($"MAC {mac} could not be found in the MAC store.")
         {


### PR DESCRIPTION
The HF sets are encoded at an older nomenclature version than the refresh runs, so a name with no data at that version is the expected case, not an error. It cost a cached-miss repeat, a throw, a second throw wrapping it, and a multi-kilobyte exception string per occurrence. This removes all four.

Three changes, one path:

1. MetadataServiceBase now caches the lookup OUTCOME, not only a hit, so a name with no data is remembered.

2. IHlaMetadataDictionary gains three additive methods - TryConvertHla, TryConvertGGroupToPGroup, TryConvertSmallGGroupToPGroup - over one new MetadataServiceBase.TryGetMetadata, which reads the same cached outcome and returns it as (bool WasFound, T Value). A name with no data now costs one dictionary probe: no InvalidHlaException, no second throw wrapping it, no catch in HlaConverterBase. The throwing methods are untouched, which keeps DonorHlaExpander, SearchRunner and RepeatSearchRunner on the expected-error pathway they use as control flow. ValueOrThrow() and ValueOrNotFound() are two accessors of one cached outcome, so whichever caller meets a bad name first pays for it and the other is served from cache. Only the three categories Match Prediction converts to - G group, P group and small g group - get a non-throwing route; serology and the two-field-allele categories keep the throwing lookup behind a catch, their failures being too rare to earn the surface.

3. The conversion-failure event drops its exception.ToString() dimension - a full async stack, multiple kilobytes - which said nothing the other five dimensions did not. An example 248-donor run reached that path 11,538 times.

BEHAVIOUR CHANGE, deliberate: an infrastructure fault now propagates. GetMetadata used to wrap EVERY exception into HlaMetadataDictionaryException and HlaConverterBase swallowed it, so a failed storage request and a missing name arrived as the same thing - a transient blip read as "this HLA does not exist", and match prediction ran on an incomplete expansion with nothing logged as an error. TryGetMetadata treats only HlaMetadataDictionaryException and its subclasses (InvalidHlaException included) as not-found; anything else escapes, on both routes, with a test for each.

Tests. MetadataServiceBaseTests gains six over a second concrete service (GGroupToPGroupMetadataService, where "in the data, and has no P group" is real): not-found without a throw, the value when found, found-with-a-null-value, one repository call across five not-found lookups, agreement with the throwing path over one cached outcome, and a TimeoutException that propagates and is NOT cached. HMD's HlaConverterTests gains eight for TryConvertHla. GroupToPGroupConverterTests is new, because GGroupToPGroupConverter and SmallGGroupToPGroupConverter had no test at all, and the case that needed one is found-with-no-P-group - a group of null-expressing alleles, which must stay found rather than be logged as a failure and retried at the other version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1513)
<!-- Reviewable:end -->
