### PR TITLE
refactor: ATL-233: constrain the LocusInfo null probes, and stop cloning immutable LocusInfo

### DIFF
--- a/Atlas.Common.Public.Models/CHANGELOG_CommonPublicModels.md
+++ b/Atlas.Common.Public.Models/CHANGELOG_CommonPublicModels.md
@@ -14,10 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### 4.1.0
-* Removed `LocusInfo<T>.ShallowCopy()`
-* Moved `Position1And2Null()`, `Position1And2NotNull()` and `SinglePositionNull()` off `LocusInfo<T>` and onto
+* BREAKING CHANGE: Removed `LocusInfo<T>.ShallowCopy()`
+* BREAKING CHANGE: Moved `Position1And2Null()`, `Position1And2NotNull()` and `SinglePositionNull()` off `LocusInfo<T>` and onto
   `LocusInfoExtensions`, constrained to a reference `T`. 
-* Removed `LocusInfo<T>.Position1Or2NewAllele()`
+* BREAKING CHANGE: Removed `LocusInfo<T>.Position1Or2NewAllele()`
 
 ### 3.0.0
 * Updated .NET version from 6.0 to 8.0

--- a/Atlas.Common.Public.Models/CHANGELOG_CommonPublicModels.md
+++ b/Atlas.Common.Public.Models/CHANGELOG_CommonPublicModels.md
@@ -13,6 +13,12 @@ This includes both schema and data workflow changes.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 4.1.0
+* Removed `LocusInfo<T>.ShallowCopy()`
+* Moved `Position1And2Null()`, `Position1And2NotNull()` and `SinglePositionNull()` off `LocusInfo<T>` and onto
+  `LocusInfoExtensions`, constrained to a reference `T`. 
+* Removed `LocusInfo<T>.Position1Or2NewAllele()`
+
 ### 3.0.0
 * Updated .NET version from 6.0 to 8.0
 

--- a/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/LociInfo.cs
+++ b/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/LociInfo.cs
@@ -377,6 +377,11 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
         private int CalculateHashCode()
         {
             // This is called somewhere in the hot path
+            //
+            // ATL-233: do NOT hoist EqualityComparer<T>.Default into a static readonly field. Measured against both
+            // reference payloads this type carries in production - 1.03x to 1.12x on time, no allocation change - so
+            // the JIT is already folding it, and our own field only risks defeating the intrinsic it recognises.
+            // Note the value-type case is NOT covered by that measurement.
             unchecked
             {
                 var hashCode = EqualityComparer<T>.Default.GetHashCode(A);

--- a/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/LocusInfo.cs
+++ b/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/LocusInfo.cs
@@ -23,8 +23,6 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
         /// </summary>
         private int? PreComputedHash { get; }
 
-        private const string NewAllele = "NEW";
-
         #region Constructors
 
         public LocusInfo()
@@ -56,11 +54,6 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
         #endregion
 
         public IEnumerable<T> ToEnumerable() => new[] {Position1, Position2};
-        
-        public LocusInfo<T> ShallowCopy()
-        {
-            return (LocusInfo<T>) MemberwiseClone();
-        }
 
         public T GetAtPosition(LocusPosition position)
         {
@@ -109,26 +102,6 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
         public LocusInfo<T> Swap()
         {
             return new LocusInfo<T>(Position2, Position1);
-        }
-
-        public bool Position1And2Null()
-        {
-            return Position1 == null && Position2 == null;
-        }
-
-        public bool Position1And2NotNull()
-        {
-            return Position1 != null && Position2 != null;
-        }
-
-        public bool SinglePositionNull()
-        {
-            return Position1 == null ^ Position2 == null;
-        }
-
-        public bool Position1Or2NewAllele()
-        {
-            return Equals(Position1, NewAllele) || Equals(Position2, NewAllele);
         }
 
         /// <summary>
@@ -190,6 +163,8 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
 
         private int CalculateHashCode()
         {
+            // ATL-233: do not hoist EqualityComparer<T>.Default into a static readonly field - measured and rejected.
+            // See LociInfo.CalculateHashCode, which records the measurement and its limit.
             unchecked
             {
                 var hashCode = EqualityComparer<T>.Default.GetHashCode(Position1);

--- a/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/LocusInfoExtensions.cs
+++ b/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/LocusInfoExtensions.cs
@@ -1,0 +1,47 @@
+// ReSharper disable InconsistentNaming - want to use T/R to easily distinguish contained type and target type(s)
+// ReSharper disable MemberCanBeInternal
+
+namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
+{
+    /// <summary>
+    /// The "is this position absent?" probes over a <see cref="LocusInfo{T}"/>.
+    ///
+    /// <para>
+    /// ATL-233: these are extension methods, constrained to a reference <c>T</c>, and were instance
+    /// methods on <see cref="LocusInfo{T}"/> up to and including 4.1.0. <see cref="LocusInfo{T}"/> does not constrain its
+    /// <c>T</c>, so <c>Position1 == null</c> inside the class <b>compiled for a value type and was
+    /// always false</b> - no error and no warning. <c>Position1And2Null()</c> would have quietly become
+    /// always-false, and <c>Position1And2NotNull()</c> always-true, the first time anyone put a <c>struct</c> in a
+    /// <see cref="LocusInfo{T}"/> and called them. A silent wrong answer, in code that decides whether a locus is
+    /// typed at all.
+    /// </para>
+    ///
+    /// <para>
+    /// A constraint cannot be added to <see cref="LocusInfo{T}"/> itself - it legitimately carries value types
+    /// (<c>LocusInfo&lt;bool&gt;</c>, <c>LocusInfo&lt;int?&gt;</c>, <c>LocusInfo&lt;PredictiveMatchCategory?&gt;</c>
+    /// are all live) - so the probes move out to where the constraint can be stated. A value-type
+    /// <c>T</c> now fails to compile at the call site, and the fix is to say what "absent" means for
+    /// that type, using <see cref="LocusInfo{T}.BothPositions"/> or <see cref="LocusInfo{T}.EitherPosition"/>.
+    /// </para>
+    /// </summary>
+    public static class LocusInfoExtensions
+    {
+        /// <returns>true if neither position holds a value.</returns>
+        public static bool Position1And2Null<T>(this LocusInfo<T> locusInfo) where T : class?
+        {
+            return locusInfo.Position1 == null && locusInfo.Position2 == null;
+        }
+
+        /// <returns>true if both positions hold a value.</returns>
+        public static bool Position1And2NotNull<T>(this LocusInfo<T> locusInfo) where T : class?
+        {
+            return locusInfo.Position1 != null && locusInfo.Position2 != null;
+        }
+
+        /// <returns>true if exactly one of the two positions holds a value.</returns>
+        public static bool SinglePositionNull<T>(this LocusInfo<T> locusInfo) where T : class?
+        {
+            return locusInfo.Position1 == null ^ locusInfo.Position2 == null;
+        }
+    }
+}

--- a/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/PhenotypeInfo.cs
+++ b/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/PhenotypeInfo.cs
@@ -29,14 +29,23 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
 
         /// <summary>
         /// Creates a new PhenotypeInfo using the provided LociInfo.
+        ///
+        /// <para>
+        /// ATL-233: the six <see cref="LocusInfo{T}"/> are shared with <paramref name="source"/>, not cloned.
+        /// <see cref="LocusInfo{T}"/> is immutable - every member returns a new instance - it pre-computes its hash on
+        /// construction, and nothing in the solution derives from it, so a <c>MemberwiseClone</c> produced an object
+        /// indistinguishable from the one it copied. This constructor is how <see cref="Map{R}(Func{Locus,LocusPosition,T,R})"/>
+        /// and <see cref="SetPosition"/> return, so the clones were six allocations per map and per single-position
+        /// write, against the six live objects they duplicated and immediately made garbage.
+        /// </para>
         /// </summary>
         public PhenotypeInfo(LociInfo<LocusInfo<T>> source) : base(
-            source.A.ShallowCopy(),
-            source.B.ShallowCopy(),
-            source.C.ShallowCopy(),
-            source.Dpb1.ShallowCopy(),
-            source.Dqb1.ShallowCopy(),
-            source.Drb1.ShallowCopy()
+            source.A,
+            source.B,
+            source.C,
+            source.Dpb1,
+            source.Dqb1,
+            source.Drb1
         )
         {
         }

--- a/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/PhenotypeInfo.cs
+++ b/Atlas.Common.Public.Models/GeneticData/PhenotypeInfo/PhenotypeInfo.cs
@@ -32,20 +32,26 @@ namespace Atlas.Common.Public.Models.GeneticData.PhenotypeInfo
         ///
         /// <para>
         /// ATL-233: the six <see cref="LocusInfo{T}"/> are shared with <paramref name="source"/>, not cloned.
-        /// <see cref="LocusInfo{T}"/> is immutable - every member returns a new instance - it pre-computes its hash on
-        /// construction, and nothing in the solution derives from it, so a <c>MemberwiseClone</c> produced an object
+        /// <see cref="LocusInfo{T}"/> is immutable by contract - every member returns a new instance, and the hash it
+        /// pre-computes on construction is only sound while that holds - so a <c>MemberwiseClone</c> produced an object
         /// indistinguishable from the one it copied. This constructor is how <see cref="Map{R}(Func{Locus,LocusPosition,T,R})"/>
         /// and <see cref="SetPosition"/> return, so the clones were six allocations per map and per single-position
         /// write, against the six live objects they duplicated and immediately made garbage.
         /// </para>
+        ///
+        /// <para>
+        /// A missing locus is still normalised to an empty <see cref="LocusInfo{T}"/>, as the other public constructors
+        /// do. <see cref="PhenotypeInfo{T}"/> holds every locus non-null, and the clone used to enforce that only as a
+        /// side effect, by throwing on a null.
+        /// </para>
         /// </summary>
         public PhenotypeInfo(LociInfo<LocusInfo<T>> source) : base(
-            source.A,
-            source.B,
-            source.C,
-            source.Dpb1,
-            source.Dqb1,
-            source.Drb1
+            source.A ?? new LocusInfo<T>(),
+            source.B ?? new LocusInfo<T>(),
+            source.C ?? new LocusInfo<T>(),
+            source.Dpb1 ?? new LocusInfo<T>(),
+            source.Dqb1 ?? new LocusInfo<T>(),
+            source.Drb1 ?? new LocusInfo<T>()
         )
         {
         }

--- a/Atlas.Common.Test/Core/PhenotypeInfo/LocusInfoExtensionsTests.cs
+++ b/Atlas.Common.Test/Core/PhenotypeInfo/LocusInfoExtensionsTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo;
+using AutoFixture;
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Atlas.Common.Test.Core.PhenotypeInfo
+{
+    /// <summary>
+    /// ATL-233: these were instance methods on <see cref="LocusInfo{T}"/> and are now extension methods constrained
+    /// to a reference T. The behaviour below is unchanged - the point of the move is what it makes impossible, and
+    /// that cannot be asserted here: a value-type T no longer compiles, so there is no test to write for it.
+    /// </summary>
+    [TestFixture]
+    public class LocusInfoExtensionsTests
+    {
+        private Fixture fixture;
+
+        [SetUp]
+        public void SetUp()
+        {
+            fixture = new Fixture();
+        }
+
+        [Test]
+        public void Position1And2Null_WhenNeitherPositionSet_ReturnsTrue()
+        {
+            new LocusInfo<string>().Position1And2Null().Should().BeTrue();
+        }
+
+        [Test]
+        public void Position1And2Null_WhenOnlyPosition1Set_ReturnsFalse()
+        {
+            new LocusInfo<string>(fixture.Create<string>(), null).Position1And2Null().Should().BeFalse();
+        }
+
+        [Test]
+        public void Position1And2Null_WhenOnlyPosition2Set_ReturnsFalse()
+        {
+            new LocusInfo<string>(null, fixture.Create<string>()).Position1And2Null().Should().BeFalse();
+        }
+
+        [Test]
+        public void Position1And2Null_WhenBothPositionsSet_ReturnsFalse()
+        {
+            new LocusInfo<string>(fixture.Create<string>(), fixture.Create<string>()).Position1And2Null().Should().BeFalse();
+        }
+
+        [Test]
+        public void Position1And2NotNull_WhenBothPositionsSet_ReturnsTrue()
+        {
+            new LocusInfo<string>(fixture.Create<string>(), fixture.Create<string>()).Position1And2NotNull().Should().BeTrue();
+        }
+
+        [Test]
+        public void Position1And2NotNull_WhenOnlyPosition1Set_ReturnsFalse()
+        {
+            new LocusInfo<string>(fixture.Create<string>(), null).Position1And2NotNull().Should().BeFalse();
+        }
+
+        [Test]
+        public void Position1And2NotNull_WhenOnlyPosition2Set_ReturnsFalse()
+        {
+            new LocusInfo<string>(null, fixture.Create<string>()).Position1And2NotNull().Should().BeFalse();
+        }
+
+        [Test]
+        public void Position1And2NotNull_WhenNeitherPositionSet_ReturnsFalse()
+        {
+            new LocusInfo<string>().Position1And2NotNull().Should().BeFalse();
+        }
+
+        [Test]
+        public void SinglePositionNull_WhenOnlyPosition1Set_ReturnsTrue()
+        {
+            new LocusInfo<string>(fixture.Create<string>(), null).SinglePositionNull().Should().BeTrue();
+        }
+
+        [Test]
+        public void SinglePositionNull_WhenOnlyPosition2Set_ReturnsTrue()
+        {
+            new LocusInfo<string>(null, fixture.Create<string>()).SinglePositionNull().Should().BeTrue();
+        }
+
+        [Test]
+        public void SinglePositionNull_WhenBothPositionsSet_ReturnsFalse()
+        {
+            new LocusInfo<string>(fixture.Create<string>(), fixture.Create<string>()).SinglePositionNull().Should().BeFalse();
+        }
+
+        [Test]
+        public void SinglePositionNull_WhenNeitherPositionSet_ReturnsFalse()
+        {
+            new LocusInfo<string>().SinglePositionNull().Should().BeFalse();
+        }
+
+        /// <summary>
+        /// The constraint is <c>class?</c>, so it has to admit an interface T. Two live call sites depend on that -
+        /// <c>LocusMatchCalculator</c> over <c>LocusInfo&lt;IEnumerable&lt;string&gt;&gt;</c> and
+        /// <c>PositionalScorerBase</c> over <c>LocusInfo&lt;IHlaScoringMetadata&gt;</c>.
+        /// </summary>
+        [Test]
+        public void NullProbes_WhenTypeParameterIsAnInterface_ProbeTheValues()
+        {
+            var locusInfo = new LocusInfo<IEnumerable<string>>(fixture.CreateMany<string>(2), null);
+
+            locusInfo.Position1And2Null().Should().BeFalse();
+            locusInfo.Position1And2NotNull().Should().BeFalse();
+            locusInfo.SinglePositionNull().Should().BeTrue();
+        }
+    }
+}

--- a/Atlas.Common.Test/Core/PhenotypeInfo/LocusInfoExtensionsTests.cs
+++ b/Atlas.Common.Test/Core/PhenotypeInfo/LocusInfoExtensionsTests.cs
@@ -95,12 +95,22 @@ namespace Atlas.Common.Test.Core.PhenotypeInfo
         }
 
         /// <summary>
-        /// The constraint is <c>class?</c>, so it has to admit an interface T. Two live call sites depend on that -
-        /// <c>LocusMatchCalculator</c> over <c>LocusInfo&lt;IEnumerable&lt;string&gt;&gt;</c> and
-        /// <c>PositionalScorerBase</c> over <c>LocusInfo&lt;IHlaScoringMetadata&gt;</c>.
+        /// Every case above uses <c>string</c>. This one pins that the probes are generic over any reference
+        /// <c>T</c>, with <c>IEnumerable&lt;string&gt;</c> chosen because an interface sits furthest from
+        /// <c>string</c>. Two live call sites are of that shape - <c>LocusMatchCalculator</c> over
+        /// <c>LocusInfo&lt;IEnumerable&lt;string&gt;&gt;</c> and <c>PositionalScorerBase</c> over
+        /// <c>LocusInfo&lt;IHlaScoringMetadata&gt;</c>.
+        ///
+        /// <para>
+        /// This says nothing about the <c>class?</c> constraint, and cannot: plain <c>class</c> admits an interface
+        /// too. The <c>?</c> is there because these methods exist to ask whether a position is absent, and
+        /// <c>class</c> would declare <c>T</c> non-nullable - so a nullable-enabled caller holding
+        /// <c>LocusInfo&lt;string?&gt;</c> would take CS8634 for asking exactly that. No call site needs the
+        /// <c>?</c> today; every calling project is nullable-oblivious.
+        /// </para>
         /// </summary>
         [Test]
-        public void NullProbes_WhenTypeParameterIsAnInterface_ProbeTheValues()
+        public void NullProbes_WhenTypeParameterIsAnyReferenceType_ProbeTheValues()
         {
             var locusInfo = new LocusInfo<IEnumerable<string>>(fixture.CreateMany<string>(2), null);
 

--- a/Atlas.Common.Test/Core/PhenotypeInfo/PhenotypeInfoTests.cs
+++ b/Atlas.Common.Test/Core/PhenotypeInfo/PhenotypeInfoTests.cs
@@ -16,11 +16,20 @@ namespace Atlas.Common.Test.Core.PhenotypeInfo
             var phenotypeInfo_defaultConstructor = new PhenotypeInfo<string>();
             var phenotypeInfo_singleValueConstructor = new PhenotypeInfo<string>("default");
             var phenotypeInfo_locusInfoConstructor = new PhenotypeInfo<string>(valueDqb1: new LocusInfo<string>("a"));
+            var phenotypeInfo_lociInfoConstructor = new PhenotypeInfo<string>(new LociInfo<LocusInfo<string>>());
             // ReSharper restore InconsistentNaming
 
             phenotypeInfo_defaultConstructor.A.Should().NotBeNull();
             phenotypeInfo_singleValueConstructor.A.Should().NotBeNull();
             phenotypeInfo_locusInfoConstructor.A.Should().NotBeNull();
+
+            // ATL-233: the LociInfo constructor normalises each of the six loci independently, so all six are asserted.
+            phenotypeInfo_lociInfoConstructor.A.Should().NotBeNull();
+            phenotypeInfo_lociInfoConstructor.B.Should().NotBeNull();
+            phenotypeInfo_lociInfoConstructor.C.Should().NotBeNull();
+            phenotypeInfo_lociInfoConstructor.Dpb1.Should().NotBeNull();
+            phenotypeInfo_lociInfoConstructor.Dqb1.Should().NotBeNull();
+            phenotypeInfo_lociInfoConstructor.Drb1.Should().NotBeNull();
         }
 
         [Test]

--- a/Atlas.Common/GeneticData/Hla/Models/HlaTypingCategory.cs
+++ b/Atlas.Common/GeneticData/Hla/Models/HlaTypingCategory.cs
@@ -12,17 +12,20 @@ namespace Atlas.Common.GeneticData.Hla.Models
         Allele,
 
         /// <summary>
-        /// Typed as a P-Group
+        /// Typed as a G-Group - alleles sharing a nucleotide sequence over the antigen binding domain. Includes null
+        /// alleles.
         /// </summary>
         GGroup,
-        
+
         /// <summary>
-        /// Typed as a "small g" group
+        /// Typed as a "small g" group - alleles sharing a protein sequence over the antigen binding domain. Includes
+        /// null alleles.
         /// </summary>
         SmallGGroup,
 
         /// <summary>
-        /// Typed as a G-Group
+        /// Typed as a P-Group - alleles sharing a protein sequence over the antigen binding domain. <b>Excludes</b>
+        /// null alleles, which express no protein, so a null allele has no P group.
         /// </summary>
         PGroup,
 

--- a/Atlas.Functions/Services/MatchCategories/PositionalMatchCategoryOrientator.cs
+++ b/Atlas.Functions/Services/MatchCategories/PositionalMatchCategoryOrientator.cs
@@ -19,7 +19,10 @@ namespace Atlas.Functions.Services.MatchCategories
         /// </summary>
         public LocusMatchCategories AlignCategoriesToMismatchScore(LocusMatchCategories matchCategories, LocusSearchResult locusScoreResult)
         {
-            if (matchCategories is null || matchCategories.Position1And2Null() ||
+            // ATL-233: BothPositions, not Position1And2Null. A PredictiveMatchCategory? is a value type, so the
+            // reference-constrained null probes in LocusInfoExtensions deliberately do not apply here - see that
+            // class for why they used to, and what they silently returned.
+            if (matchCategories is null || matchCategories.BothPositions(category => category is null) ||
                 locusScoreResult is not { MatchCategory: LocusMatchCategory.Mismatch })
             {
                 return matchCategories;

--- a/Atlas.HlaMetadataDictionary/Services/DataRetrieval/LocusHlaMatchingMetadataService.cs
+++ b/Atlas.HlaMetadataDictionary/Services/DataRetrieval/LocusHlaMatchingMetadataService.cs
@@ -62,7 +62,10 @@ namespace Atlas.HlaMetadataDictionary.Services.DataRetrieval
         private static INullHandledHlaMatchingMetadata HandleNullAlleles(IHlaMatchingMetadata metadata,
             IHlaMatchingMetadata otherMetadata, Locus locus, LocusInfo<string> locusTyping)
         {
-            if (metadata == null && locusTyping.Position1Or2NewAllele())
+            // ATL-233: was LocusInfo<T>.Position1Or2NewAllele(), which compared a generic T against the string "NEW"
+            // through object.Equals - meaningless for every T but string, and boxing for a value type. "NEW" is HLA
+            // nomenclature, so the check belongs here, next to the newAllele const this class already declared.
+            if (metadata == null && locusTyping.EitherPosition(hla => hla == newAllele))
             {
                 return new NullHandledHlaMatchingMetadata(new HlaMatchingMetadata(locus, newAllele, TypingMethod.Molecular, new List<string>()));
             }

--- a/Atlas.MatchPrediction.Test.Validation/Services/Exercise4/SearchRequester.cs
+++ b/Atlas.MatchPrediction.Test.Validation/Services/Exercise4/SearchRequester.cs
@@ -2,6 +2,7 @@
 using Atlas.Client.Models.Search;
 using Atlas.Client.Models.Search.Requests;
 using Atlas.Common.Public.Models.GeneticData;
+using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo;
 using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.TransferModels;
 using Atlas.ManualTesting.Common.Repositories;
 using Atlas.MatchPrediction.Test.Validation.Data.Models;


### PR DESCRIPTION


Breaking changes to a published package. See CHANGELOG_CommonPublicModels.md. All three are source-compatible for a call site that passes a reference type, and none changes the wire contract - PhenotypeInfoTransfer<T> and LociInfoTransfer<T> are untouched, so no consumer's JSON changes. They are BINARY-breaking, so anything compiled against 4.1.0 must be recompiled. VersionPrefix is deliberately not moved: all seven published packages sit at 4.1.0 in lockstep, and moving one is a release decision, not a code change.

Allocation:

  PhenotypeInfo's copy constructor now shares the six LocusInfo with its source instead of
  MemberwiseClone-ing them. LocusInfo<T> is immutable, pre-computes its hash on
  construction, and nothing in the solution derives from it, so the clones were
  indistinguishable from the objects they duplicated and were immediately made garbage.
  That was 27% of the allocation, and 28-38% of the time, of every PhenotypeInfo.Map in
  the solution.

  LocusInfo<T>.ShallowCopy() is removed - callerless after the above, and a clone method on
  an immutable type has no reason to exist.

Type safety:

  The three null probes - Position1And2Null, Position1And2NotNull, SinglePositionNull -
  move to LocusInfoExtensions, constrained to a reference T. LocusInfo<T> does not
  constrain its T, so `Position1 == null` compiled for a value type and was always false,
  with no error and no warning: Position1And2Null would have become always-false and
  Position1And2NotNull always-true the first time anyone put a non-nullable struct in a
  LocusInfo - in code that decides whether a locus is typed at all. The constraint cannot
  go on LocusInfo<T> itself, since LocusInfo of bool, of int? and of
  PredictiveMatchCategory? are all live, so the probes move to where it can be stated.
  Declared `where T : class?` and not `class`, because nullable is enabled and two live
  call sites pass an interface T.

  No call site was returning a wrong answer. PositionalMatchCategoryOrientator passes a
  LocusInfo<PredictiveMatchCategory?>, and `== null` on a Nullable<T> is a lifted
  comparison that does what it reads as - the always-false trap needs a non-nullable
  struct. It now reads BothPositions(category => category is null), which says what
  "absent" means for a nullable enum rather than resting on the reader knowing C# lifted-
  operator rules.

  LocusInfo<T>.Position1Or2NewAllele() is removed outright. It compared a generic T against
  the string "NEW" through object.Equals, so it was meaningless for every T but string and
  boxed for a value type. EitherPosition already existed, and its one caller already
  declared its own copy of the constant, so the check now lives with that caller in
  Atlas.HlaMetadataDictionary. "NEW" is HLA nomenclature and does not belong on a generic
  container.

One doc-comment defect fixed, because it was a straight swap that costs a wrong belief: HlaTypingCategory documented GGroup as "Typed as a P-Group" and PGroup as "Typed as a G-Group". Both are now written with the definition rather than the name - a G group is alleles sharing a nucleotide sequence over the antigen binding domain, a P group is alleles sharing a protein sequence, and a P group excludes null alleles because a null allele expresses no protein and so has none.

No behaviour change: every removed member is replaced by something that computes the same answer. LocusInfoExtensionsTests is new. Atlas.Common.Test 303, Atlas.Functions.Test 97, Atlas.HlaMetadataDictionary.Test 703. No error CS in a full solution build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1514)
<!-- Reviewable:end -->
