### PR TITLE
fix: ATL-337: address PR #1517 review feedback

### DIFF
--- a/Atlas.MatchPrediction.Functions/Functions/Debug/GenotypeImputationFunctions.cs
+++ b/Atlas.MatchPrediction.Functions/Functions/Debug/GenotypeImputationFunctions.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.TransferModels;
 using Atlas.Common.Public.Models.MatchPrediction;
@@ -48,11 +47,8 @@ namespace Atlas.MatchPrediction.Functions.Functions.Debug
             });
 
             // The result carries each kept genotype together with its name form and likelihood, so the name-keyed view
-            // this debug response shows is projected here rather than held in the result. One entry per surviving name
-            // form: two genotypes differing only in typing category share one.
-            var likelihoodsByName = imputedGenotypes.Genotypes
-                .GroupBy(genotype => genotype.Names)
-                .ToDictionary(group => group.Key, group => group.First().Likelihood);
+            // this debug response shows is projected here rather than held in the result.
+            var likelihoodsByName = imputedGenotypes.LikelihoodsByName();
 
             return new JsonResult(new GenotypeImputationResponse
             {

--- a/Atlas.MatchPrediction.Test/Services/HaplotypeFrequencies/HaplotypeFrequencyCacheTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/HaplotypeFrequencies/HaplotypeFrequencyCacheTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Atlas.Common.ApplicationInsights;
 using Atlas.Common.Caching;
 using Atlas.Common.Public.Models.GeneticData;
 using Atlas.Common.Test.SharedTestHelpers.Builders;
@@ -15,6 +16,7 @@ using AutoFixture;
 using AwesomeAssertions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using HfSetHaplotypeNames = Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.LociInfo<string>;
 
@@ -243,6 +245,37 @@ internal class HaplotypeFrequencyCacheTests
         // The standing hazard is a second writer of ConsolidatedFrequencies. Awaiting inside the GetOrAddAsync
         // factory is what prevents it: concurrent callers share one lazy task rather than each starting a warm.
         frequencyConsolidator.Received(1).PreConsolidateFrequenciesForCommonMissingLoci(Arg.Any<FrequencySetCacheEntry>());
+    }
+
+    [Test]
+    public async Task GetAllHaplotypeFrequencies_WhenAwaitingTheWarm_AndPreConsolidationThrows_PropagatesTheFailure()
+    {
+        const int setId = 9;
+        var awaitingSut = BuildSut(awaitConsolidatedFrequencyWarm: true);
+        frequencyRepository.GetAllHaplotypeFrequencies(setId).Returns([Record("a", "b", "c", "dqb1", "drb1", 0.5m)]);
+        frequencyConsolidator.PreConsolidateFrequenciesForCommonMissingLoci(Arg.Any<FrequencySetCacheEntry>())
+            .Throws(new InvalidOperationException("boom"));
+
+        // Awaiting the warm exists precisely so a caller never gets back an entry whose ConsolidatedFrequencies is
+        // silently stuck null - a failed pre-consolidation must surface here, not be swallowed.
+        await awaitingSut.Invoking(c => c.GetAllHaplotypeFrequencies(setId)).Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task GetAllHaplotypeFrequencies_WhenNotAwaitingTheWarm_AndPreConsolidationThrows_LogsAndReturnsUnwarmedEntry()
+    {
+        const int setId = 10;
+        frequencyRepository.GetAllHaplotypeFrequencies(setId).Returns([Record("a", "b", "c", "dqb1", "drb1", 0.5m)]);
+        frequencyConsolidator.PreConsolidateFrequenciesForCommonMissingLoci(Arg.Any<FrequencySetCacheEntry>())
+            .Throws(new InvalidOperationException("boom"));
+
+        // The background path has no awaiter to propagate to, so the failure must be caught and logged rather than
+        // faulting an unobserved task - the caller still gets an entry back, just an unwarmed one.
+        var entry = await sut.GetAllHaplotypeFrequencies(setId);
+        await WaitUntil(() => logger.ReceivedCalls().Any());
+
+        entry.ConsolidatedFrequencies.Should().BeNull();
+        logger.Received(1).SendTrace(Arg.Is<string>(msg => msg.Contains("Failed to warm consolidated frequency cache")), LogLevel.Error);
     }
 
     private async Task WaitForConsolidation(int setId) =>

--- a/Atlas.MatchPrediction.Test/Services/MatchProbability/ExpandedGenotypeTruncaterTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/MatchProbability/ExpandedGenotypeTruncaterTests.cs
@@ -29,8 +29,10 @@ namespace Atlas.MatchPrediction.Test.Services.MatchProbability;
 /// <para>
 /// Two consequences worth stating, because a bounded heap gets them wrong unless it is told not to:
 /// <see cref="TruncateGenotypes_WhenLikelihoodsTie_KeepsTheEarliestInserted"/> (which of the tied keys survive) and
-/// <see cref="TruncateGenotypes_SumsTheKeptLikelihoodsInDescendingLikelihoodOrder"/> (the ORDER the kept likelihoods
-/// are summed in, which <c>decimal</c> addition can see).
+/// <see cref="MostLikelyFirst_OrdersByDescendingLikelihood"/> (the ORDER the kept likelihoods are summed in, which
+/// <c>decimal</c> addition can see). <see cref="ImputedGenotypes.Genotypes"/> is in expansion order, not this order,
+/// so that second invariant is pinned directly against <c>MostLikelyFirst</c> rather than through
+/// <c>TruncateGenotypes</c>'s result.
 /// </para>
 /// </summary>
 [TestFixture]
@@ -119,14 +121,31 @@ internal class ExpandedGenotypeTruncaterTests
 
         // decimal carries scale, so the sum's scale is the widest addend's - hence 0.600, three places, from 0.200.
         // Addition itself is exact until the 96-bit mantissa overflows, which likelihood magnitudes never approach, so
-        // the order is not observable here. It is asserted below anyway, because the truncater selects in
-        // descending-likelihood order and folds the sum during that same pass, and that must not quietly change.
-        // Genotypes enumerate in expansion order instead, which is a different order and deliberately so - it is the
-        // one downstream reads.
+        // the summation order is not observable in this value - MostLikelyFirst_OrdersByDescendingLikelihood pins that
+        // order directly instead. Genotypes enumerate in expansion order here, which is a different order and
+        // deliberately so - it is the one downstream reads.
         result.SumOfLikelihoods.Should().Be(0.600m);
         result.SumOfLikelihoods.ToString().Should().Be("0.600");
         result.SumOfLikelihoods.Should().Be(0.30m + 0.200m + 0.1m);
         result.GenotypesOnly().Should().Equal(a, b, c);
+    }
+
+    [Test]
+    public void MostLikelyFirst_OrdersByDescendingLikelihood()
+    {
+        // TruncateGenotypes enumerates MostLikelyFirst's result once, to both select survivors and fold
+        // sumOfLikelihoods - so this is the order that folding actually runs in. ImputedGenotypes.Genotypes doesn't
+        // expose it (it's in expansion order, for downstream consumers), so it's pinned here directly.
+        var likelihoods = new Dictionary<GenotypeNameKey, decimal>
+        {
+            [new GenotypeNameKey(0, 1)] = 0.1m,
+            [new GenotypeNameKey(2, 3)] = 0.30m,
+            [new GenotypeNameKey(4, 5)] = 0.200m
+        };
+
+        var result = ExpandedGenotypeTruncater.MostLikelyFirst(likelihoods, maximum: 3);
+
+        result.Values.Should().BeInDescendingOrder();
     }
 
     [Test]

--- a/Atlas.MatchPrediction.Test/Services/MatchProbability/GenotypeConverterTests.cs
+++ b/Atlas.MatchPrediction.Test/Services/MatchProbability/GenotypeConverterTests.cs
@@ -15,7 +15,8 @@ using AutoFixture;
 using AwesomeAssertions;
 using NSubstitute;
 using NUnit.Framework;
-using GenotypeOfKnownTypingCategory = Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.PhenotypeInfo<Atlas.MatchPrediction.ExternalInterface.Models.HlaAtKnownTypingCategory>;
+using GenotypeOfKnownTypingCategory =
+    Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.PhenotypeInfo<Atlas.MatchPrediction.ExternalInterface.Models.HlaAtKnownTypingCategory>;
 using HfSetGenotypeNames = Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.PhenotypeInfo<string>;
 
 namespace Atlas.MatchPrediction.Test.Services.MatchProbability;

--- a/Atlas.MatchPrediction.Test/TestHelpers/Builders/ImputedGenotypesBuilder.cs
+++ b/Atlas.MatchPrediction.Test/TestHelpers/Builders/ImputedGenotypesBuilder.cs
@@ -67,12 +67,14 @@ namespace Atlas.MatchPrediction.Test.TestHelpers.Builders
 
         public GenotypeAtDesiredResolutionsBuilder Default()
         {
-            genotypeAtDesiredResolutions = new GenotypeAtDesiredResolutions
-            {
-                HaplotypeResolution = new PhenotypeInfoBuilder<string>(BuilderDefaults.HlaName).Build(),
-                StringMatchableResolution = new PhenotypeInfo<string>(BuilderDefaults.HlaName),
-                GenotypeLikelihood = BuilderDefaults.Likelihood
-            };
+            // Built from an ImputedGenotype, the same way GenotypeConverter builds one, so HaplotypeResolution and
+            // GenotypeLikelihood come from one source rather than two independent literals.
+            var genotype = new ImputedGenotype(
+                new KnownTypingCategoryGenotypeBuilder(BuilderDefaults.HlaName).Build(),
+                new PhenotypeInfoBuilder<string>(BuilderDefaults.HlaName).Build(),
+                BuilderDefaults.Likelihood);
+
+            genotypeAtDesiredResolutions = new GenotypeAtDesiredResolutions(genotype, new PhenotypeInfo<string>(BuilderDefaults.HlaName));
 
             return this;
         }

--- a/Atlas.MatchPrediction.Test/TestHelpers/ImputedGenotypesExtensions.cs
+++ b/Atlas.MatchPrediction.Test/TestHelpers/ImputedGenotypesExtensions.cs
@@ -7,22 +7,15 @@ using Atlas.MatchPrediction.Models;
 namespace Atlas.MatchPrediction.Test.TestHelpers;
 
 /// <summary>
-/// Two views of <see cref="ImputedGenotypes"/> that the result no longer carries itself: a set of genotypes, and a
-/// likelihood dictionary keyed by name form. Kept here so that assertions can be written against the values a caller
-/// cares about, rather than against the shape the result is carried in.
+/// A view of <see cref="ImputedGenotypes"/> that the result no longer carries itself: a set of genotypes, without
+/// their name forms or likelihoods. Kept here so that assertions can be written against the values a caller cares
+/// about, rather than against the shape the result is carried in. The name-keyed likelihood view,
+/// <c>LikelihoodsByName</c>, lives in production code (<see cref="ImputedGenotypesExtensions"/> in
+/// <c>Atlas.MatchPrediction.Models</c>) since <c>GenotypeImputationFunctions</c> needs the same projection.
 /// </summary>
-internal static class ImputedGenotypesExtensions
+internal static class ImputedGenotypesTestExtensions
 {
     /// <summary>The kept genotypes alone, in the order the expansion produced them.</summary>
     public static IReadOnlyList<PhenotypeInfo<HlaAtKnownTypingCategory>> GenotypesOnly(this ImputedGenotypes imputed) =>
         imputed.Genotypes.Select(genotype => genotype.Genotype).ToList();
-
-    /// <summary>
-    /// One entry per surviving name form. Grouped rather than <c>ToDictionary</c> because two genotypes can share a
-    /// name form - the collapse case - and they carry one likelihood between them.
-    /// </summary>
-    public static Dictionary<PhenotypeInfo<string>, decimal> LikelihoodsByName(this ImputedGenotypes imputed) =>
-        imputed.Genotypes
-            .GroupBy(genotype => genotype.Names)
-            .ToDictionary(group => group.Key, group => group.First().Likelihood);
 }

--- a/Atlas.MatchPrediction.Worker/appsettings.json
+++ b/Atlas.MatchPrediction.Worker/appsettings.json
@@ -28,7 +28,7 @@
   },
   "HaplotypeFrequencySetCache": {
     "ActiveSetCacheExpiryMinutes": 5,
-    "AwaitConsolidatedFrequencyWarm": false
+    "AwaitConsolidatedFrequencyWarm": true
   },
   "GenotypeImputation": {
     "MaximumExpandedGenotypesPerInput": 2000

--- a/Atlas.MatchPrediction/Models/GenotypeAtDesiredResolutions.cs
+++ b/Atlas.MatchPrediction/Models/GenotypeAtDesiredResolutions.cs
@@ -10,12 +10,23 @@ using PGroupGenotype = Atlas.Common.Public.Models.GeneticData.PhenotypeInfo.Phen
 namespace Atlas.MatchPrediction.Models;
 
 /// <remarks>
-/// Built through an object initialiser rather than a constructor. <see cref="HaplotypeResolution"/> and
-/// <see cref="StringMatchableResolution"/> are both <c>PhenotypeInfo&lt;string&gt;</c>, so as constructor arguments a
-/// caller could transpose them and the compiler would not notice. Named at the initialiser, it cannot happen silently.
+/// Built through a constructor taking an <see cref="ImputedGenotype"/> rather than its <see cref="HaplotypeResolution"/>
+/// and <see cref="GenotypeLikelihood"/> as independent arguments: both come from the one <c>ImputedGenotype</c>, whose
+/// <c>Names</c>/<c>Genotype</c> pairing is already guaranteed correct upstream (see
+/// <c>ExpandedGenotypes.MaterialiseNames</c>), so the two cannot be set from unrelated sources here. Re-deriving
+/// <c>HaplotypeResolution</c> via <c>ToHlaNames()</c> on every call, as an earlier version of this type did, would
+/// reintroduce the per-genotype cost <c>GenotypeConverter</c> exists to avoid - <c>ImputedGenotype.Names</c> is already
+/// that derivation, computed once upstream.
 /// </remarks>
 public class GenotypeAtDesiredResolutions
 {
+    public GenotypeAtDesiredResolutions(ImputedGenotype genotype, PGroupGenotype stringMatchableResolution)
+    {
+        HaplotypeResolution = genotype.Names;
+        GenotypeLikelihood = genotype.Likelihood;
+        StringMatchableResolution = stringMatchableResolution;
+    }
+
     /// <summary>
     /// HLA at the resolution at which they were stored.
     /// I.e. P group, or G group where a null allele meant no P group existed.
@@ -28,7 +39,7 @@ public class GenotypeAtDesiredResolutions
     /// a per-row column and one set can hold both resolutions.
     /// </para>
     /// </summary>
-    public HfSetGenotypeNames HaplotypeResolution { get; init; }
+    public HfSetGenotypeNames HaplotypeResolution { get; }
 
     /// <summary>
     /// HLA at a resolution at which it is possible to calculate match counts using string comparison only, no expansion.
@@ -39,13 +50,13 @@ public class GenotypeAtDesiredResolutions
     /// says what it holds. <c>IMatchCalculationService.CalculateMatchCounts_Fast</c> carries the evidence.
     /// </para>
     /// </summary>
-    public PGroupGenotype StringMatchableResolution { get; init; }
+    public PGroupGenotype StringMatchableResolution { get; }
 
     /// <summary>
     /// Likelihood of this genotype.
     ///
     /// Stored with the genotype to avoid dictionary lookups when calculating final likelihoods, as looking up the same genotype multiple times
-    /// for different patient/donor pairs is inefficient 
+    /// for different patient/donor pairs is inefficient
     /// </summary>
-    public decimal GenotypeLikelihood { get; init; }
+    public decimal GenotypeLikelihood { get; }
 }

--- a/Atlas.MatchPrediction/Models/ImputedGenotypesExtensions.cs
+++ b/Atlas.MatchPrediction/Models/ImputedGenotypesExtensions.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using Atlas.Common.Public.Models.GeneticData.PhenotypeInfo;
+
+namespace Atlas.MatchPrediction.Models;
+
+/// <summary>A view of <see cref="ImputedGenotypes"/> that the result no longer carries itself.</summary>
+public static class ImputedGenotypesExtensions
+{
+    /// <summary>
+    /// One entry per surviving name form. Grouped rather than <c>ToDictionary</c> because two genotypes can share a
+    /// name form - the collapse case - and they carry one likelihood between them.
+    /// </summary>
+    public static Dictionary<PhenotypeInfo<string>, decimal> LikelihoodsByName(this ImputedGenotypes imputed) =>
+        imputed.Genotypes
+            .GroupBy(genotype => genotype.Names)
+            .ToDictionary(group => group.Key, group => group.First().Likelihood);
+}

--- a/Atlas.MatchPrediction/Services/CompressedPhenotypeExpansion/CompressedPhenotypeExpander.cs
+++ b/Atlas.MatchPrediction/Services/CompressedPhenotypeExpansion/CompressedPhenotypeExpander.cs
@@ -76,7 +76,8 @@ internal interface ICompressedPhenotypeExpander
 /// <para>
 /// <b><see cref="Likelihoods"/> is keyed by <see cref="GenotypeNameKey"/> - the ids of the genotype's two haplotype
 /// name forms - not by the name form itself.</b> The key still <i>means</i> "this genotype's HLA names", matching
-/// <c>ImputedGenotypes.GenotypeLikelihoods</c>, so its count is the DISTINCT genotype count while
+/// <c>ImputedGenotype.Names</c> (each kept genotype's <c>ImputedGenotype.Likelihood</c> is keyed conceptually by that
+/// same name form), so its count is the DISTINCT genotype count while
 /// <see cref="GenotypePairs"/> keeps typing category and so may hold more; eight bytes carry that identity instead of
 /// seven heap objects. See <see cref="GenotypeNameKey"/> for why the two are the same equality rather than an
 /// approximation of it.
@@ -424,30 +425,21 @@ internal class CompressedPhenotypeExpander : ICompressedPhenotypeExpander
     /// Survivors that differ only in typing category, or only at a locus this key excludes, have equal name forms and
     /// therefore share an id - which is precisely the collapse <see cref="ExpandedGenotypes.Likelihoods"/> performs,
     /// moved from the genotype to the haplotype. The dictionary is over S entries, paid once, against the up-to-1.65M
-    /// kept pairs that would otherwise build a <c>PhenotypeInfo</c> each.
+    /// kept pairs that would otherwise build a <c>PhenotypeInfo</c> each. Uses the same first-seen-wins
+    /// dictionary+list idiom as <see cref="AlleleInterner"/>, via the shared <see cref="Interner{TKey}"/>.
     /// </remarks>
     private static (int[] NameIdBySurvivor, IReadOnlyList<HfSetHaplotypeNames> HaplotypeNamesById) InternHaplotypeNames(
         IReadOnlyList<LociInfo<HlaAtKnownTypingCategory>> survivors)
     {
-        var idByName = new Dictionary<HfSetHaplotypeNames, int>(survivors.Count);
+        var interner = new Interner<HfSetHaplotypeNames>();
         var nameIdBySurvivor = new int[survivors.Count];
-        var haplotypeNamesById = new List<HfSetHaplotypeNames>(survivors.Count);
 
         for (var h = 0; h < survivors.Count; h++)
         {
-            var names = survivors[h].Map(hla => hla?.Hla);
-
-            if (!idByName.TryGetValue(names, out var id))
-            {
-                id = haplotypeNamesById.Count;
-                idByName[names] = id;
-                haplotypeNamesById.Add(names);
-            }
-
-            nameIdBySurvivor[h] = id;
+            nameIdBySurvivor[h] = interner.Intern(survivors[h].Map(hla => hla?.Hla));
         }
 
-        return (nameIdBySurvivor, haplotypeNamesById);
+        return (nameIdBySurvivor, interner.KeyById);
     }
 
     /// <summary>

--- a/Atlas.MatchPrediction/Services/HaplotypeFrequencies/AlleleInterner.cs
+++ b/Atlas.MatchPrediction/Services/HaplotypeFrequencies/AlleleInterner.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-using System;
-using System.Collections.Generic;
+#nullable enable
 
 namespace Atlas.MatchPrediction.Services.HaplotypeFrequencies;
 
@@ -11,18 +9,15 @@ public sealed class AlleleInterner
     // This sentinel is for lookups only: it must never be stored as a key, persisted, or passed to GetName.
     public const int NotFound = -1;
 
-    private readonly Dictionary<string, int> toId = new(StringComparer.Ordinal);
-    private readonly List<string?> toName = [null]; // index 0 = "absent"
+    // Ids here are offset by 1 from the shared interner's: id 0 is reserved for "absent/untyped", so a real allele's
+    // id is 1 + its Interner<string> id.
+    private readonly Interner<string> inner = new();
 
     // Load time: assigns a new id if unseen.
     public int Intern(string? allele)
     {
         if (string.IsNullOrEmpty(allele)) return 0;
-        if (toId.TryGetValue(allele, out var id)) return id;
-        id = toName.Count;
-        toId.Add(allele, id);
-        toName.Add(allele);
-        return id;
+        return 1 + inner.Intern(allele);
     }
 
     // Query time: never mints new ids. Miss => allele absent from this set.
@@ -30,13 +25,20 @@ public sealed class AlleleInterner
     {
         if (!string.IsNullOrEmpty(allele))
         {
-            return toId.TryGetValue(allele, out id);
+            if (inner.TryGetId(allele, out var innerId))
+            {
+                id = 1 + innerId;
+                return true;
+            }
+
+            id = 0;
+            return false;
         }
 
         id = 0;
         return true;
     }
-    
+
     // Query time: returns 0 for an untyped (null/empty) allele, the interned id for a known allele,
     // or NotFound when the allele is absent from this set. Use this (not 0) to distinguish "not in set"
     // from "untyped" - the result is safe for dictionary lookups but must not be passed to GetName.
@@ -46,9 +48,9 @@ public sealed class AlleleInterner
     }
 
     // Maps any non-positive id (including the NotFound sentinel) back to "no allele", keeping ReverseLookup total.
-    public string? GetName(int id) => id <= 0 ? null : toName[id];
+    public string? GetName(int id) => id <= 0 ? null : inner.KeyById[id - 1];
 
     // One past the highest id this interner has minted - ids are dense from 0, so this sizes an array indexed by id.
     // That array is what lets the pool filter test an allele without hashing anything.
-    internal int IdCount => toName.Count;
+    internal int IdCount => inner.KeyById.Count + 1;
 }

--- a/Atlas.MatchPrediction/Services/HaplotypeFrequencies/HaplotypeFrequencyCache.cs
+++ b/Atlas.MatchPrediction/Services/HaplotypeFrequencies/HaplotypeFrequencyCache.cs
@@ -127,15 +127,17 @@ internal class HaplotypeFrequencyCache : IHaplotypeFrequencyCache
                     // Inside the GetOrAddAsync factory, so the wait happens once per set and every concurrent caller
                     // for the same set awaits the same lazy task rather than racing it. When this returns,
                     // ConsolidatedFrequencies is populated and no caller can reach the direct-scan fallback, which is
-                    // the whole point - a scan costs roughly a thousand times a warm read.
-                    WarmConsolidatedFrequencies(setId, entry);
+                    // the whole point - a scan costs roughly a thousand times a warm read. A failure here propagates
+                    // out of this factory instead of being swallowed, so GetOrAddAsync does not cache a half-warmed
+                    // entry and the next caller for this set retries from scratch.
+                    WarmConsolidatedFrequencies(setId, entry, rethrowOnFailure: true);
                 }
                 else
                 {
                     // The right behaviour where a request is waiting: the full pre-consolidation is slow and must not
                     // delay the first lookup, which falls back to a direct calculation while ConsolidatedFrequencies
                     // is null.
-                    _ = Task.Run(() => WarmConsolidatedFrequencies(setId, entry));
+                    _ = Task.Run(() => WarmConsolidatedFrequencies(setId, entry, rethrowOnFailure: false));
                 }
 
                 return entry;
@@ -200,7 +202,14 @@ internal class HaplotypeFrequencyCache : IHaplotypeFrequencyCache
         return result;
     }
 
-    private void WarmConsolidatedFrequencies(int setId, FrequencySetCacheEntry entry)
+    /// <param name="rethrowOnFailure">
+    /// True when called on the awaited path: a caller of <see cref="GetAllHaplotypeFrequencies"/> asked to wait for
+    /// the warm precisely so it wouldn't get back an entry whose <see cref="FrequencySetCacheEntry.ConsolidatedFrequencies"/>
+    /// stays null forever. Swallowing here would leave every subsequent lookup silently falling back to the slow
+    /// per-haplotype scan with no retry. False on the background (non-awaited) path, where there is no awaiter to
+    /// propagate to and an unobserved task exception would be worse than a logged one.
+    /// </param>
+    private void WarmConsolidatedFrequencies(int setId, FrequencySetCacheEntry entry, bool rethrowOnFailure)
     {
         try
         {
@@ -214,6 +223,11 @@ internal class HaplotypeFrequencyCache : IHaplotypeFrequencyCache
         catch (Exception e)
         {
             logger.SendTrace($"Failed to warm consolidated frequency cache for set {setId}: {e.Message}", LogLevel.Error);
+
+            if (rethrowOnFailure)
+            {
+                throw;
+            }
         }
     }
 

--- a/Atlas.MatchPrediction/Services/HaplotypeFrequencies/Interner.cs
+++ b/Atlas.MatchPrediction/Services/HaplotypeFrequencies/Interner.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Atlas.MatchPrediction.Services.HaplotypeFrequencies;
+
+/// <summary>
+/// Dense sequential ids for distinct keys, first-seen-wins. The dictionary+list idiom shared by
+/// <see cref="AlleleInterner"/> (interning a single locus's allele string) and
+/// <c>CompressedPhenotypeExpander.InternHaplotypeNames</c> (interning a whole haplotype's name form) - kept in one
+/// place so a future fix to interning semantics applies to both.
+/// </summary>
+internal sealed class Interner<TKey> where TKey : notnull
+{
+    private readonly Dictionary<TKey, int> idByKey = new();
+    private readonly List<TKey> keyById = new();
+
+    /// <summary>Assigns a new id if <paramref name="key"/> is unseen, otherwise returns its existing one.</summary>
+    public int Intern(TKey key)
+    {
+        if (!idByKey.TryGetValue(key, out var id))
+        {
+            id = keyById.Count;
+            idByKey[key] = id;
+            keyById.Add(key);
+        }
+
+        return id;
+    }
+
+    /// <summary>Query time: never mints new ids. Miss => key not seen by this interner.</summary>
+    public bool TryGetId(TKey key, out int id) => idByKey.TryGetValue(key, out id);
+
+    /// <summary>Dense ids from 0, one entry per distinct key interned, in first-seen order.</summary>
+    public IReadOnlyList<TKey> KeyById => keyById;
+}

--- a/Atlas.MatchPrediction/Services/MatchProbability/ExpandedGenotypeTruncater.cs
+++ b/Atlas.MatchPrediction/Services/MatchProbability/ExpandedGenotypeTruncater.cs
@@ -128,7 +128,13 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
         /// arbitrary eviction. <c>ExpandedGenotypeTruncaterTests</c> pins it.
         /// </para>
         /// </summary>
-        private static Dictionary<GenotypeNameKey, decimal> MostLikelyFirst(
+        /// <remarks>
+        /// Internal, not private: <c>ExpandedGenotypeTruncaterTests</c> asserts directly on this method's output order,
+        /// since <see cref="ImputedGenotypes.Genotypes"/> is deliberately in expansion order rather than this method's
+        /// descending-likelihood order, so nothing else exposes the order this method - and the summation in
+        /// <see cref="TruncateGenotypes"/> above - actually runs in.
+        /// </remarks>
+        internal static Dictionary<GenotypeNameKey, decimal> MostLikelyFirst(
             Dictionary<GenotypeNameKey, decimal> likelihoods,
             int maximum)
         {

--- a/Atlas.MatchPrediction/Services/MatchProbability/GenotypeConverter.cs
+++ b/Atlas.MatchPrediction/Services/MatchProbability/GenotypeConverter.cs
@@ -97,7 +97,7 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
                 // again because survivors share names heavily - that sharing is what makes a reduced allowed-loci key
                 // collapse the survivor count in the first place. Pass 2 is then pure dictionary reads and allocates no
                 // task at all.
-                var pGroups = await ResolveDistinctPGroups(
+                var (pGroups, adjustedGenotypes) = await ResolveDistinctPGroups(
                     input, noNullAllelesInCompressedPhenotype, nullAlleleInfoByPosition, hfSetHmd, matchingHmd);
 
                 // Hoisted out of the loop deliberately: this closes over `pGroups` alone, so one delegate serves every
@@ -109,19 +109,11 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
                 // No ToHlaNames() and no likelihood lookup: the truncater built that name form in order to select this
                 // genotype, and hands it over with the likelihood it selected it by. A phenotype-keyed probe here would
                 // be a twelve-object hash - and on collision a twelve-position equality - per kept genotype, for a
-                // value that was never in doubt.
-                foreach (var imputed in input.Genotypes)
+                // value that was never in doubt. Nor is the null-allele adjustment redone: ResolveDistinctPGroups
+                // already computed it once per genotype below, and hands the adjusted genotype back index-aligned.
+                for (var i = 0; i < input.Genotypes.Count; i++)
                 {
-                    var genotypeToConvert = noNullAllelesInCompressedPhenotype
-                        ? imputed.Genotype
-                        : AccountForNullAlleleInCompressedPhenotype(imputed.Genotype, nullAlleleInfoByPosition);
-
-                    converted.Add(new GenotypeAtDesiredResolutions
-                    {
-                        HaplotypeResolution = imputed.Names,
-                        StringMatchableResolution = genotypeToConvert.MapByLocus(toPGroupsAtLocus),
-                        GenotypeLikelihood = imputed.Likelihood
-                    });
+                    converted.Add(new GenotypeAtDesiredResolutions(input.Genotypes[i], adjustedGenotypes[i].MapByLocus(toPGroupsAtLocus)));
                 }
 
                 return converted;
@@ -130,16 +122,10 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
 
         /// <summary>
         /// The (locus, name, typing category) triples every kept genotype holds, each converted to its P group exactly
-        /// one time.
+        /// one time - and each kept genotype's own null-allele-adjusted form, index-aligned with
+        /// <see cref="GenotypeConverterInput.Genotypes"/>, for the caller's build loop to reuse without recomputing it.
         /// </summary>
-        /// <remarks>
-        /// The genotypes are walked twice - here and in the caller's build loop - and the null-allele adjustment is
-        /// applied on both passes rather than being carried between them. The two passes are order-independent (this one
-        /// only accumulates into a set), and the adjustment is a no-op unless the subject's own submitted typing carries
-        /// a null-expressing allele, which is the rare case. Recomputing it there costs one map on those subjects only;
-        /// carrying it would cost an array of every genotype on all of them.
-        /// </remarks>
-        private async Task<Dictionary<PGroupLookupKey, string>> ResolveDistinctPGroups(
+        private async Task<PGroupResolution> ResolveDistinctPGroups(
             GenotypeConverterInput input,
             bool noNullAllelesInCompressedPhenotype,
             PhenotypeInfo<(bool, IEnumerable<HlaAtKnownTypingCategory>)> nullAlleleInfoByPosition,
@@ -147,6 +133,7 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
             IHlaMetadataDictionary matchingHmd)
         {
             var distinct = new HashSet<PGroupLookupKey>();
+            var adjustedGenotypes = new GenotypeOfKnownTypingCategory[input.Genotypes.Count];
 
             // Hoisted for the same reason as the caller's mapping delegate.
             Action<Locus, LocusPosition, HlaAtKnownTypingCategory> collect = (locus, _, hla) =>
@@ -157,12 +144,14 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
                 }
             };
 
-            foreach (var imputed in input.Genotypes)
+            for (var i = 0; i < input.Genotypes.Count; i++)
             {
+                var imputed = input.Genotypes[i];
                 var genotypeToConvert = noNullAllelesInCompressedPhenotype
                     ? imputed.Genotype
                     : AccountForNullAlleleInCompressedPhenotype(imputed.Genotype, nullAlleleInfoByPosition);
 
+                adjustedGenotypes[i] = genotypeToConvert;
                 genotypeToConvert.EachPosition(collect);
             }
 
@@ -186,7 +175,7 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
                 resolved[keys[i]] = pGroups[i];
             }
 
-            return resolved;
+            return new PGroupResolution(resolved, adjustedGenotypes);
         }
 
         private async Task<string> ConvertToPGroup(HlaConverterInput converterInput, PGroupLookupKey key)
@@ -247,6 +236,11 @@ namespace Atlas.MatchPrediction.Services.MatchProbability
         /// answer between two triples that no longer convert alike.
         /// </remarks>
         private readonly record struct PGroupLookupKey(Locus Locus, HlaAtKnownTypingCategory Hla);
+
+        /// <summary><see cref="ResolveDistinctPGroups"/>'s result.</summary>
+        private readonly record struct PGroupResolution(
+            Dictionary<PGroupLookupKey, string> PGroups,
+            IReadOnlyList<GenotypeOfKnownTypingCategory> AdjustedGenotypes);
 
         private async Task<(bool isNullAllele, IEnumerable<HlaAtKnownTypingCategory> nullAlleleGGroups)> GetNullAlleleInfo(
             IHlaMetadataDictionary hfSetHmd,


### PR DESCRIPTION
## Summary
Follow-up to #1517 (ATL-233: genotype conversion performance improvements), addressing the 10 unresolved review comments tracked in [ATL-337](https://anthonynolan.atlassian.net/browse/ATL-337):

1. **Stale XML doc reference** - `CompressedPhenotypeExpander.cs`'s doc comment now points at `ImputedGenotype.Names`/`.Likelihood` instead of the removed `ImputedGenotypes.GenotypeLikelihoods`.
2. **Swallowed warm failure** - `HaplotypeFrequencyCache.WarmConsolidatedFrequencies` now rethrows after logging when called on the awaited path (`AwaitConsolidatedFrequencyWarm: true`), so `GetOrAddAsync` doesn't cache a half-warmed entry and the next caller retries. Still catches-and-logs on the background path. New tests cover both.
3. **`AwaitConsolidatedFrequencyWarm` shipped disabled** - flipped to `true` in `Atlas.MatchPrediction.Worker/appsettings.json`, matching the setting's own doc comment for this precompute host. Not wired into Terraform (no existing env-var override for this settings section on the Worker container app - flagging that as a separate consideration rather than bundling it here).
4. **Lost type-level derivation guarantee** - `GenotypeAtDesiredResolutions` now takes an `ImputedGenotype` in its constructor (instead of three independent init-only properties), so `HaplotypeResolution`/`GenotypeLikelihood` come from one already-consistent source rather than being set from unrelated literals.
5. **Duplicated null-allele computation** - `GenotypeConverter.ResolveDistinctPGroups` now computes each genotype's null-allele-adjusted form once and returns it (via a new `PGroupResolution` record) for the caller's build loop to reuse, instead of recomputing it a second time per genotype.
6. **Untested summation-order invariant** - `ExpandedGenotypeTruncater.MostLikelyFirst` made `internal` and a new test asserts descending-likelihood order directly on it, since `ImputedGenotypes.Genotypes` is deliberately in expansion order and no longer exposes that invariant.
7. **Hand-rolled interning** - extracted a shared `Interner<TKey>` helper; both `AlleleInterner` and `CompressedPhenotypeExpander.InternHaplotypeNames` now use it instead of two independent dictionary+list implementations.
8. **Test-only helper duplicated in production code** - `LikelihoodsByName` moved from the Test project into `Atlas.MatchPrediction.Models`, so `GenotypeImputationFunctions` and the test suite share one implementation.
9. **Three parallel index-aligned collections** - left as-is. The three-collection shape in `ExpandedGenotypeTruncater` is a deliberate, already-documented LOH-threshold tradeoff (avoiding a large dictionary entry array at the 2,000-genotype cap); collapsing it would need a benchmark to justify, so replying on the review thread instead of changing working code.
10. **Line-length violation** - the 178-char using-alias in `GenotypeConverterTests.cs` now wraps across two lines (C# using-alias directives resolve their target from the global namespace only, so it can't be shortened by relying on the file's other `using` imports).

## Test plan
- [x] `dotnet build --configuration Release` for `Atlas.MatchPrediction`, `.Functions`, `.Worker`, `.Test`, `.Test.Integration`, `.Test.Validation` - all clean, 0 errors
- [x] `dotnet test Atlas.MatchPrediction.Test` - 294 passed, 2 skipped (perf tests), 0 failed
- [x] Verified no other call sites break from the `GenotypeAtDesiredResolutions` constructor change or the moved `LikelihoodsByName` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ATL-337]: https://anthonynolan.atlassian.net/browse/ATL-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1520)
<!-- Reviewable:end -->
