### PR TITLE
feature: ATL-298: reuse SqlBulkCopy per destination table during data refresh

### DIFF
--- a/Atlas.MatchingAlgorithm.Data/Atlas.MatchingAlgorithm.Data.csproj
+++ b/Atlas.MatchingAlgorithm.Data/Atlas.MatchingAlgorithm.Data.csproj
@@ -28,6 +28,7 @@
 
     <ItemGroup>
       <InternalsVisibleTo Include="Atlas.MatchingAlgorithm.Test" />
+      <InternalsVisibleTo Include="Atlas.MatchingAlgorithm.Test.Integration" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Atlas.MatchingAlgorithm.Data/Repositories/DonorUpdates/DonorImportRepository.cs
+++ b/Atlas.MatchingAlgorithm.Data/Repositories/DonorUpdates/DonorImportRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Atlas.Common.ApplicationInsights;
@@ -46,6 +47,12 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
         /// This does _not_ refresh or create the hla matches.
         /// </summary>
         Task InsertBatchOfDonors(IEnumerable<DonorInfo> donors);
+
+        /// <summary>
+        /// Opens a session over which this repository's bulk copies are reused across writes, rather than rebuilt for
+        /// each one. Intended to be held for the length of a data refresh stage, and disposed when the stage is done.
+        /// </summary>
+        IDisposable OpenBulkWriteSession();
 
         /// <summary>
         /// Adds pre-processed matching p-groups for a batch of donors

--- a/Atlas.MatchingAlgorithm.Data/Repositories/DonorUpdates/DonorUpdateRepositoryBase.cs
+++ b/Atlas.MatchingAlgorithm.Data/Repositories/DonorUpdates/DonorUpdateRepositoryBase.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Transactions;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.ApplicationInsights.Timing;
 using Atlas.Common.Public.Models.GeneticData;
@@ -23,6 +25,22 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
     public abstract class DonorUpdateRepositoryBase : Repository
     {
         protected readonly IAtlasLogger logger;
+
+        private const string DonorsTableName = "Donors";
+
+        private const int DefaultBulkInsertTimeoutInSeconds = 3600;
+
+        /// <summary>
+        /// The matching HLA tables are the largest writes in the system, hence a far longer timeout than
+        /// <see cref="DefaultBulkInsertTimeoutInSeconds"/>. Shared with <see cref="BuildReusableBulkCopies"/>, which
+        /// pre-builds those tables' bulk copies, so that the two cannot drift apart.
+        /// </summary>
+        private const int MatchingHlaBulkInsertTimeoutInSeconds = 14400;
+
+        /// <summary>
+        /// Non-null only between <see cref="OpenBulkWriteSession"/> and the disposal of what it returned.
+        /// </summary>
+        private BulkCopySession activeBulkCopySession;
 
         // The order of these matters when setting up the datatable - if re-ordering, also re-order datatable contents
         private readonly string[] donorInsertDataTableColumnNames =
@@ -61,6 +79,30 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
             this.logger = logger;
         }
 
+        /// <summary>
+        /// Opens a session over which this repository's bulk copies are reused, rather than rebuilt per write.
+        /// Dispose the returned handle to close it.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="SqlBulkCopy"/> asks the server to describe its destination table before sending any rows, and
+        /// that description is cached per instance, so rebuilding one per write pays for a round trip that only ever
+        /// returns the same answer. Over a full data refresh that came to over an hour of waiting on the destination
+        /// metadata catalogue queries for a few minutes of server time.
+        ///
+        /// Not every write can take part - see <see cref="GetReusableBulkCopy"/> - so this is an optimisation that a
+        /// caller opts into for a whole stage, not a change to how any individual write behaves.
+        /// </remarks>
+        public IDisposable OpenBulkWriteSession()
+        {
+            if (activeBulkCopySession != null)
+            {
+                throw new InvalidOperationException($"A bulk write session is already open on this {GetType().Name}.");
+            }
+
+            activeBulkCopySession = new BulkCopySession(this);
+            return activeBulkCopySession;
+        }
+
         public async Task InsertBatchOfDonors(IEnumerable<DonorInfo> donors)
         {
             var donorInfos = donors.ToList();
@@ -72,7 +114,7 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
 
             var dataTable = BuildDonorInsertDataTable(donorInfos);
 
-            await BulkInsertDataTable("Donors", dataTable, donorInsertDataTableColumnNames);
+            await BulkInsertDataTable(DonorsTableName, dataTable, donorInsertDataTableColumnNames);
         }
 
         public async Task AddMatchingRelationsForExistingDonorBatch(
@@ -183,7 +225,15 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
             var dataTable = BuildPerLocusPGroupDataTable(donors, locus, timerCollection);
             buildDataTableTimer?.Dispose();
 
-            using (var transactionScope = new AsyncTransactionScope())
+            // The scope is here to make the DELETE below and the insert that follows it one atomic unit. On the create
+            // path there is no DELETE to be atomic with, and the insert is already atomic in its own right: the
+            // UseInternalTransaction option commits per bulk-copy batch, and one donor batch's rows at one locus
+            // (2 * HlaProcessor.BatchSize at the very most) never reach the 10,000 row batch size.
+            //
+            // Skipping it there is also what leaves the reusable bulk copies usable - see GetReusableBulkCopy. Where a
+            // caller asked for the whole upsert to be transactional, the outer scope opened by
+            // UpsertMatchingPGroupsAtSpecifiedLoci is ambient regardless, and this scope only ever joined it.
+            using (var transactionScope = new OptionalAsyncTransactionScope(!isKnownToBeCreate))
             {
                 using (timerCollection?.TimeInnerOperation(DataRefreshTimingKeys.HlaUpsert_BulkInsertSetup_DeleteExistingRecords_TimerKey))
                 {
@@ -204,7 +254,7 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
                     matchingTableName,
                     dataTable,
                     donorPGroupDataTableColumnNames,
-                    timeout: 14400,
+                    timeout: MatchingHlaBulkInsertTimeoutInSeconds,
                     timerCollection?.GetStopwatch(DataRefreshTimingKeys.HlaUpsert_DtWriteExecution_TimerKey));
 
                 transactionScope.Complete();
@@ -303,26 +353,66 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
         #region BulkInsertDataTable
 
         /// <summary>
-        /// Opens a new connection and performs a bulk insert wrapped in a transaction.
+        /// Performs a bulk insert wrapped in a transaction, over the session's bulk copy for this table where there is
+        /// one it can use, and otherwise over a newly built one on a new connection.
         /// If columnNames provided, sets up a map from dataTable to SQL, assuming a 1:1 mapping between dataTable and SQL column names  
         /// </summary>
         private async Task BulkInsertDataTable(
             string tableName,
             DataTable dataTable,
             string[] columnNames,
-            int timeout = 3600,
+            int timeout = DefaultBulkInsertTimeoutInSeconds,
             ILongOperationLoggingStopwatch longLoopDbWriteTimer = null)
         {
             using (longLoopDbWriteTimer?.TimeInnerOperation())
-            using (var sqlBulk = BuildSqlBulkCopy(tableName, columnNames, timeout))
             {
-                await sqlBulk.WriteToServerAsync(dataTable);
+                var reusableBulkCopy = GetReusableBulkCopy(tableName);
+                if (reusableBulkCopy != null)
+                {
+                    await reusableBulkCopy.WriteToServerAsync(dataTable);
+                    return;
+                }
+
+                using (var sqlBulk = BuildSqlBulkCopy(tableName, columnNames, timeout))
+                {
+                    await sqlBulk.WriteToServerAsync(dataTable);
+                }
             }
         }
 
-        private SqlBulkCopy BuildSqlBulkCopy(string tableName, string[] columnNames, int timeout = 3600)
+        /// <summary>
+        /// The open session's bulk copy for <paramref name="tableName"/>, or null if this write has to build its own.
+        /// </summary>
+        /// <remarks>
+        /// A reused bulk copy holds its connection open until it is disposed: <see cref="SqlBulkCopy"/> opens an owned
+        /// connection before its first write and has no path that closes one again. A connection enlists in the
+        /// ambient transaction when it is opened, and never again - so a reused instance takes part in whichever
+        /// <see cref="TransactionScope"/> its first write happened to run under, and in none of the scopes after it.
+        /// Once that first transaction ends, SqlClient's default "Implicit Unbind" binding detaches the connection
+        /// from it silently, or throws "The transaction associated with the current connection has completed but has
+        /// not been disposed" if the write lands before the transaction object itself is disposed. So writes made under
+        /// an ambient transaction keep building an instance of their own, and behave as they did before sessions existed.
+        ///
+        /// The silent path is the dangerous one, and it was measured rather than assumed: reusing an instance
+        /// regardless of the ambient transaction, and then rolling that transaction back, leaves the rows written - so
+        /// a run with DataRefreshDonorUpdatesShouldBeFullyTransactional set would lose transactionality from its
+        /// second batch onwards, with nothing in the logs to say so. That is what
+        /// InsertBatchOfDonors_WithinOneBulkWriteSession_UnderATransactionThatRollsBack_WritesNothing pins down, and
+        /// it is the only test that fails if the check below is dropped.
+        /// </remarks>
+        private SqlBulkCopy GetReusableBulkCopy(string tableName) =>
+            Transaction.Current == null ? activeBulkCopySession?.BulkCopyFor(tableName) : null;
+
+        private SqlBulkCopy BuildSqlBulkCopy(string tableName, string[] columnNames, int timeout = DefaultBulkInsertTimeoutInSeconds)
         {
-            var bulkCopy = new SqlBulkCopy(ConnectionStringProvider.GetConnectionString(), SqlBulkCopyOptions.UseInternalTransaction)
+            // CacheMetadata is what makes reuse worth anything: without it a bulk copy re-describes its destination
+            // table on every write, whether or not the instance is the same one as last time. It is safe here because
+            // these tables' schemas are fixed for the life of a session - the data refresh drops and recreates their
+            // indexes, which the cached column metadata does not describe - and because a session never outlives the
+            // connection string it was opened against, so it cannot survive a swap of the transient database.
+            const SqlBulkCopyOptions options = SqlBulkCopyOptions.UseInternalTransaction | SqlBulkCopyOptions.CacheMetadata;
+
+            var bulkCopy = new SqlBulkCopy(ConnectionStringProvider.GetConnectionString(), options)
             {
                 BatchSize = 10000,
                 DestinationTableName = tableName,
@@ -336,6 +426,67 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
             }
 
             return bulkCopy;
+        }
+
+        /// <summary>
+        /// One <see cref="SqlBulkCopy"/> per table this repository writes, built up front.
+        /// </summary>
+        /// <remarks>
+        /// Eagerly, because a <see cref="SqlBulkCopy"/> costs nothing until its first write - it does not even open its
+        /// connection - and because a cache populated up front needs no synchronising against the per-locus writes,
+        /// which run concurrently. One instance per table also means no instance is ever shared between those writes:
+        /// they go to one table each, and a <see cref="SqlBulkCopy"/> rejects a second concurrent write on the same
+        /// instance. Nor do successive batches overlap, since <see cref="UpsertMatchingPGroupsAtSpecifiedLoci"/> awaits
+        /// every locus' write before it returns.
+        /// </remarks>
+        private IReadOnlyDictionary<string, SqlBulkCopy> BuildReusableBulkCopies()
+        {
+            var bulkCopies = new Dictionary<string, SqlBulkCopy>
+            {
+                [DonorsTableName] = BuildSqlBulkCopy(DonorsTableName, donorInsertDataTableColumnNames)
+            };
+
+            foreach (var locus in LocusSettings.MatchingOnlyLoci)
+            {
+                var tableName = MatchingHla.TableName(locus);
+                bulkCopies[tableName] = BuildSqlBulkCopy(
+                    tableName,
+                    donorPGroupDataTableColumnNames,
+                    MatchingHlaBulkInsertTimeoutInSeconds);
+            }
+
+            return bulkCopies;
+        }
+
+        /// <summary>
+        /// The bulk copies of one <see cref="OpenBulkWriteSession"/>, and their disposal.
+        /// </summary>
+        private sealed class BulkCopySession : IDisposable
+        {
+            private readonly DonorUpdateRepositoryBase repository;
+            private readonly IReadOnlyDictionary<string, SqlBulkCopy> bulkCopiesByTableName;
+
+            internal BulkCopySession(DonorUpdateRepositoryBase repository)
+            {
+                this.repository = repository;
+                bulkCopiesByTableName = repository.BuildReusableBulkCopies();
+            }
+
+            /// <returns>This session's bulk copy for the table, or null if the session does not cover that table.</returns>
+            internal SqlBulkCopy BulkCopyFor(string tableName) =>
+                bulkCopiesByTableName.TryGetValue(tableName, out var bulkCopy) ? bulkCopy : null;
+
+            public void Dispose()
+            {
+                foreach (var bulkCopy in bulkCopiesByTableName.Values)
+                {
+                    // SqlBulkCopy implements IDisposable explicitly, so this cast is the only way to reach Dispose
+                    // other than a `using`. Disposing is what closes the connection the bulk copy has held open.
+                    ((IDisposable) bulkCopy).Dispose();
+                }
+
+                repository.activeBulkCopySession = null;
+            }
         }
 
         #endregion

--- a/Atlas.MatchingAlgorithm.Data/Repositories/DonorUpdates/DonorUpdateRepositoryBase.cs
+++ b/Atlas.MatchingAlgorithm.Data/Repositories/DonorUpdates/DonorUpdateRepositoryBase.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Atlas.Common.ApplicationInsights;
 using Atlas.Common.ApplicationInsights.Timing;
 using Atlas.Common.Public.Models.GeneticData;
 using Atlas.Common.Utils;
+using Atlas.Common.Utils.Disposable;
 using Atlas.Common.Utils.Extensions;
 using Atlas.MatchingAlgorithm.Common.Config;
 using Atlas.MatchingAlgorithm.Data.Helpers;
@@ -29,6 +31,12 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
         private const string DonorsTableName = "Donors";
 
         private const int DefaultBulkInsertTimeoutInSeconds = 3600;
+
+        /// <summary>
+        /// Rows per bulk-copy batch. With <see cref="SqlBulkCopyOptions.UseInternalTransaction"/> this is also the unit
+        /// of atomicity, which is why <see cref="UpsertMatchingPGroupsAtLocus"/> checks a write against it.
+        /// </summary>
+        private const int BulkCopyBatchSize = 10000;
 
         /// <summary>
         /// The matching HLA tables are the largest writes in the system, hence a far longer timeout than
@@ -91,6 +99,13 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
         ///
         /// Not every write can take part - see <see cref="GetReusableBulkCopy"/> - so this is an optimisation that a
         /// caller opts into for a whole stage, not a change to how any individual write behaves.
+        ///
+        /// Which writes those are is worth knowing before measuring anything. Donor creation is the only path that
+        /// benefits: the update path holds a real transaction throughout, for DELETE and insert atomicity, so its
+        /// writes always build their own instance. And with DataRefreshDonorUpdatesShouldBeFullyTransactional set, the
+        /// outer scope wraps every write in the batch, creates included, so reuse becomes a no-op for the whole
+        /// refresh while a session is still opened and closed per stage. Closing a session traces how many writes
+        /// actually reused a bulk copy, so neither case has to be inferred from this class.
         /// </remarks>
         public IDisposable OpenBulkWriteSession()
         {
@@ -100,7 +115,11 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
             }
 
             activeBulkCopySession = new BulkCopySession(this);
-            return activeBulkCopySession;
+
+            // Wrapped, rather than returned directly, so that closing is idempotent: DisposableAction already tracks
+            // that for the codebase. A second disposal that ran Close again would clear whatever session is registered
+            // by then - orphaning a newer session's bulk copies, and the connections they hold, rather than nothing.
+            return new DisposableAction(activeBulkCopySession.Close);
         }
 
         public async Task InsertBatchOfDonors(IEnumerable<DonorInfo> donors)
@@ -226,14 +245,17 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
             buildDataTableTimer?.Dispose();
 
             // The scope is here to make the DELETE below and the insert that follows it one atomic unit. On the create
-            // path there is no DELETE to be atomic with, and the insert is already atomic in its own right: the
-            // UseInternalTransaction option commits per bulk-copy batch, and one donor batch's rows at one locus
-            // (2 * HlaProcessor.BatchSize at the very most) never reach the 10,000 row batch size.
+            // path there is no DELETE to be atomic with, and a write that fits in a single bulk-copy batch is already
+            // atomic in its own right, because UseInternalTransaction commits per batch. So the scope is skipped only
+            // when both hold - and the second is checked against the rows in hand rather than assumed from the batch
+            // size a caller happens to use, so that raising that batch size costs reuse here instead of atomicity.
             //
-            // Skipping it there is also what leaves the reusable bulk copies usable - see GetReusableBulkCopy. Where a
+            // Skipping it is also what leaves the reusable bulk copies usable - see GetReusableBulkCopy. Where a
             // caller asked for the whole upsert to be transactional, the outer scope opened by
             // UpsertMatchingPGroupsAtSpecifiedLoci is ambient regardless, and this scope only ever joined it.
-            using (var transactionScope = new OptionalAsyncTransactionScope(!isKnownToBeCreate))
+            var writeIsAtomicWithoutAScope = isKnownToBeCreate && dataTable.Rows.Count <= BulkCopyBatchSize;
+
+            using (var transactionScope = new OptionalAsyncTransactionScope(!writeIsAtomicWithoutAScope))
             {
                 using (timerCollection?.TimeInnerOperation(DataRefreshTimingKeys.HlaUpsert_BulkInsertSetup_DeleteExistingRecords_TimerKey))
                 {
@@ -414,7 +436,7 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
 
             var bulkCopy = new SqlBulkCopy(ConnectionStringProvider.GetConnectionString(), options)
             {
-                BatchSize = 10000,
+                BatchSize = BulkCopyBatchSize,
                 DestinationTableName = tableName,
                 BulkCopyTimeout = timeout
             };
@@ -438,6 +460,10 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
         /// they go to one table each, and a <see cref="SqlBulkCopy"/> rejects a second concurrent write on the same
         /// instance. Nor do successive batches overlap, since <see cref="UpsertMatchingPGroupsAtSpecifiedLoci"/> awaits
         /// every locus' write before it returns.
+        ///
+        /// Every table this class writes, rather than the subset the calling stage writes to - donor import only writes
+        /// Donors, HLA processing only the locus tables - because an unused instance costs an allocation and a disposal
+        /// and never reaches the database, which is not worth splitting this method, or its caller's API, in two for.
         /// </remarks>
         private IReadOnlyDictionary<string, SqlBulkCopy> BuildReusableBulkCopies()
         {
@@ -459,12 +485,17 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
         }
 
         /// <summary>
-        /// The bulk copies of one <see cref="OpenBulkWriteSession"/>, and their disposal.
+        /// The bulk copies of one <see cref="OpenBulkWriteSession"/>, and their closing.
         /// </summary>
-        private sealed class BulkCopySession : IDisposable
+        private sealed class BulkCopySession
         {
             private readonly DonorUpdateRepositoryBase repository;
             private readonly IReadOnlyDictionary<string, SqlBulkCopy> bulkCopiesByTableName;
+
+            /// <summary>
+            /// Written to from the concurrent per-locus writes, hence interlocked.
+            /// </summary>
+            private int reusedWriteCount;
 
             internal BulkCopySession(DonorUpdateRepositoryBase repository)
             {
@@ -473,10 +504,20 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
             }
 
             /// <returns>This session's bulk copy for the table, or null if the session does not cover that table.</returns>
-            internal SqlBulkCopy BulkCopyFor(string tableName) =>
-                bulkCopiesByTableName.TryGetValue(tableName, out var bulkCopy) ? bulkCopy : null;
+            internal SqlBulkCopy BulkCopyFor(string tableName)
+            {
+                if (!bulkCopiesByTableName.TryGetValue(tableName, out var bulkCopy))
+                {
+                    return null;
+                }
 
-            public void Dispose()
+                // Only reached once the caller has decided to reuse - see GetReusableBulkCopy - so this counts writes
+                // that were actually spared building an instance, not writes that asked.
+                Interlocked.Increment(ref reusedWriteCount);
+                return bulkCopy;
+            }
+
+            internal void Close()
             {
                 foreach (var bulkCopy in bulkCopiesByTableName.Values)
                 {
@@ -486,6 +527,24 @@ namespace Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates
                 }
 
                 repository.activeBulkCopySession = null;
+                ReportReuse();
+            }
+
+            /// <summary>
+            /// One trace per session, so that a session which reused nothing - and therefore saved nothing - can be
+            /// seen in the logs of a run rather than deduced from the code.
+            /// </summary>
+            private void ReportReuse()
+            {
+                var reusedWrites = reusedWriteCount;
+                var message = reusedWrites == 0
+                    ? "Bulk write session closed without reusing any bulk copy - every write ran under an ambient transaction."
+                    : $"Bulk write session closed. {reusedWrites} writes reused a bulk copy instead of building one.";
+
+                repository.logger.SendTrace(message, props: new Dictionary<string, string>
+                {
+                    {"ReusedWrites", reusedWrites.ToString()}
+                });
             }
         }
 

--- a/Atlas.MatchingAlgorithm.Test.Integration/IntegrationTests/Import/DonorStorageTests.cs
+++ b/Atlas.MatchingAlgorithm.Test.Integration/IntegrationTests/Import/DonorStorageTests.cs
@@ -3,6 +3,7 @@ using Atlas.Common.GeneticData.PhenotypeInfo;
 using Atlas.MatchingAlgorithm.Client.Models.Donors;
 using Atlas.MatchingAlgorithm.Data.Models.DonorInfo;
 using Atlas.MatchingAlgorithm.Data.Repositories;
+using Atlas.MatchingAlgorithm.Data.Services;
 using Atlas.MatchingAlgorithm.Data.Repositories.DonorRetrieval;
 using Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates;
 using Atlas.MatchingAlgorithm.Services.ConfigurationProviders.TransientSqlDatabase.ConnectionStringProviders;
@@ -10,9 +11,11 @@ using Atlas.MatchingAlgorithm.Services.ConfigurationProviders.TransientSqlDataba
 using Atlas.MatchingAlgorithm.Test.Integration.TestHelpers;
 using Atlas.MatchingAlgorithm.Test.Integration.TestHelpers.Builders;
 using Atlas.MatchingAlgorithm.Test.Integration.TestHelpers.Repositories;
+using Atlas.Common.ApplicationInsights;
 using Atlas.Common.Utils;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -32,6 +35,7 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Import
         private IDonorInspectionRepository inspectionRepo;
         private IHlaImportRepository hlaImportRepository;
         private TestDonorInspectionRepository testInspectionRepo;
+        private IConnectionStringProvider dormantConnectionStringProvider;
 
         private readonly DonorInfoWithExpandedHla donorInfoWithAllelesAtThreeLoci = new DonorInfoWithExpandedHla
         {
@@ -103,7 +107,7 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Import
             inspectionRepo = repositoryFactory.GetDonorInspectionRepository();
             hlaImportRepository = repositoryFactory.GetHlaImportRepository();
 
-            var dormantConnectionStringProvider = DependencyInjection.DependencyInjection.Provider
+            dormantConnectionStringProvider = DependencyInjection.DependencyInjection.Provider
                 .GetService<DormantTransientSqlConnectionStringProvider>();
             testInspectionRepo = new TestDonorInspectionRepository(dormantConnectionStringProvider);
         }
@@ -365,6 +369,27 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Import
 
             (await inspectionRepo.GetDonor(warmUpDonor.DonorId)).Should().NotBeNull();
             (await inspectionRepo.GetDonor(rolledBackDonor.DonorId)).Should().BeNull();
+        }
+
+        [Test]
+        public async Task InsertBatchOfDonors_WithinOneBulkWriteSession_TracesHowManyWritesReusedABulkCopy()
+        {
+            // Guards the count itself: a trace that always reported zero would satisfy the unit test covering a session
+            // that reused nothing, and would then be silently useless for the case it exists to reveal.
+            var logger = Substitute.For<IAtlasLogger>();
+            var repository = new DonorImportRepository(
+                Substitute.For<IHlaNamesRepository>(), dormantConnectionStringProvider, logger);
+
+            using (repository.OpenBulkWriteSession())
+            {
+                await repository.InsertBatchOfDonors(new List<DonorInfo> {new DonorInfoBuilder().Build()});
+                await repository.InsertBatchOfDonors(new List<DonorInfo> {new DonorInfoBuilder().Build()});
+            }
+
+            logger.Received(1).SendTrace(
+                Arg.Any<string>(),
+                Arg.Any<LogLevel>(),
+                Arg.Is<Dictionary<string, string>>(p => p["ReusedWrites"] == "2"));
         }
 
         private static DonorInfoWithExpandedHla BuildDonorWithRequiredHla() =>

--- a/Atlas.MatchingAlgorithm.Test.Integration/IntegrationTests/Import/DonorStorageTests.cs
+++ b/Atlas.MatchingAlgorithm.Test.Integration/IntegrationTests/Import/DonorStorageTests.cs
@@ -2,11 +2,15 @@
 using Atlas.Common.GeneticData.PhenotypeInfo;
 using Atlas.MatchingAlgorithm.Client.Models.Donors;
 using Atlas.MatchingAlgorithm.Data.Models.DonorInfo;
+using Atlas.MatchingAlgorithm.Data.Repositories;
 using Atlas.MatchingAlgorithm.Data.Repositories.DonorRetrieval;
 using Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates;
+using Atlas.MatchingAlgorithm.Services.ConfigurationProviders.TransientSqlDatabase.ConnectionStringProviders;
 using Atlas.MatchingAlgorithm.Services.ConfigurationProviders.TransientSqlDatabase.RepositoryFactories;
 using Atlas.MatchingAlgorithm.Test.Integration.TestHelpers;
 using Atlas.MatchingAlgorithm.Test.Integration.TestHelpers.Builders;
+using Atlas.MatchingAlgorithm.Test.Integration.TestHelpers.Repositories;
+using Atlas.Common.Utils;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -26,6 +30,8 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Import
         private IDonorImportRepository donorImportRepository;
         private IDonorUpdateRepository donorUpdateRepository;
         private IDonorInspectionRepository inspectionRepo;
+        private IHlaImportRepository hlaImportRepository;
+        private TestDonorInspectionRepository testInspectionRepo;
 
         private readonly DonorInfoWithExpandedHla donorInfoWithAllelesAtThreeLoci = new DonorInfoWithExpandedHla
         {
@@ -95,6 +101,11 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Import
             donorImportRepository = repositoryFactory.GetDonorImportRepository();
             donorUpdateRepository = repositoryFactory.GetDonorUpdateRepository();
             inspectionRepo = repositoryFactory.GetDonorInspectionRepository();
+            hlaImportRepository = repositoryFactory.GetHlaImportRepository();
+
+            var dormantConnectionStringProvider = DependencyInjection.DependencyInjection.Provider
+                .GetService<DormantTransientSqlConnectionStringProvider>();
+            testInspectionRepo = new TestDonorInspectionRepository(dormantConnectionStringProvider);
         }
 
         [Test]
@@ -260,5 +271,126 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.IntegrationTests.Import
             actualDonorInfo.IsAvailableForSearch.Should().Be(expectedDonorInfo.IsAvailableForSearch);
             actualDonorInfo.HlaNames.Should().BeEquivalentTo(expectedDonorInfo.HlaNames);
         }
+
+        #region Bulk write sessions
+
+        // A session's bulk copies are reused across every write in it, and hold a connection open for its whole
+        // length - so these cover that successive writes over one session all land, and that reuse is declined while a
+        // transaction is ambient, which is the only part of this that would otherwise fail silently.
+
+        [Test]
+        public async Task InsertBatchOfDonors_WithinOneBulkWriteSession_InsertsEveryBatch()
+        {
+            var firstDonor = new DonorInfoBuilder().Build();
+            var secondDonor = new DonorInfoBuilder().Build();
+
+            using (donorImportRepository.OpenBulkWriteSession())
+            {
+                await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {firstDonor});
+                await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {secondDonor});
+            }
+
+            (await inspectionRepo.GetDonor(firstDonor.DonorId)).Should().NotBeNull();
+            (await inspectionRepo.GetDonor(secondDonor.DonorId)).Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task AddMatchingRelationsForExistingDonorBatch_WithinOneBulkWriteSession_InsertsRelationsForEveryBatch()
+        {
+            var firstDonor = BuildDonorWithRequiredHla();
+            var secondDonor = BuildDonorWithRequiredHla();
+            await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {firstDonor, secondDonor});
+
+            using (donorImportRepository.OpenBulkWriteSession())
+            {
+                await AddMatchingRelationsFor(firstDonor);
+                await AddMatchingRelationsFor(secondDonor);
+            }
+
+            testInspectionRepo.GetMatchingHlaRowCount(Locus.A, firstDonor.DonorId).Should().Be(2);
+            testInspectionRepo.GetMatchingHlaRowCount(Locus.A, secondDonor.DonorId).Should().Be(2);
+        }
+
+        [Test]
+        public void OpenBulkWriteSession_WhenASessionIsAlreadyOpen_ThrowsException()
+        {
+            using (donorImportRepository.OpenBulkWriteSession())
+            {
+                Assert.Throws<InvalidOperationException>(() => donorImportRepository.OpenBulkWriteSession());
+            }
+        }
+
+        [Test]
+        public async Task InsertBatchOfDonors_AfterABulkWriteSessionIsClosed_StillInsertsDonors()
+        {
+            // The session's bulk copies, and the connections they held, are disposed with it; writes after it has to
+            // fall back to building their own again.
+            using (donorImportRepository.OpenBulkWriteSession())
+            {
+                await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {new DonorInfoBuilder().Build()});
+            }
+
+            var donorAfterSession = new DonorInfoBuilder().Build();
+            await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {donorAfterSession});
+
+            (await inspectionRepo.GetDonor(donorAfterSession.DonorId)).Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task InsertBatchOfDonors_WithinOneBulkWriteSession_UnderATransactionThatRollsBack_WritesNothing()
+        {
+            // A bulk copy enlists in the ambient transaction once, when its connection is opened, and takes part in no
+            // scope after that - so a session's bulk copy, whose connection an earlier write already opened, would
+            // write straight past this rollback. Declining to reuse one while a transaction is ambient is what makes
+            // the second write below undoable, and this is the only test that fails if that decision is removed.
+            //
+            // Donors, rather than the matching HLA tables, because this write has to put exactly one connection into
+            // the transaction: AddMatchingRelationsForExistingDonorBatch writes at all five matching loci whether or
+            // not a donor has HLA at them, and five connections in one transaction would promote it to a distributed
+            // transaction, which is unsupported off Windows.
+            var warmUpDonor = new DonorInfoBuilder().Build();
+            var rolledBackDonor = new DonorInfoBuilder().Build();
+
+            using (donorImportRepository.OpenBulkWriteSession())
+            {
+                // Written with no transaction ambient, so the session's bulk copy for Donors opens its connection here.
+                await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {warmUpDonor});
+
+                using (new AsyncTransactionScope())
+                {
+                    await donorImportRepository.InsertBatchOfDonors(new List<DonorInfo> {rolledBackDonor});
+                    // Deliberately not completed, so disposing the scope rolls this write back.
+                }
+            }
+
+            (await inspectionRepo.GetDonor(warmUpDonor.DonorId)).Should().NotBeNull();
+            (await inspectionRepo.GetDonor(rolledBackDonor.DonorId)).Should().BeNull();
+        }
+
+        private static DonorInfoWithExpandedHla BuildDonorWithRequiredHla() =>
+            new DonorInfoWithTestHlaBuilder(DonorIdGenerator.NextId())
+                .WithDefaultRequiredHla(new TestHlaMetadata
+                {
+                    LookupName = "01:01",
+                    MatchingPGroups = new List<string> {"01:01P"}
+                })
+                .Build();
+
+        /// <summary>
+        /// Imports a donor's HLA and then writes its matching relations, which is what the HLA processing stage of the
+        /// data refresh does for every batch.
+        /// </summary>
+        private async Task AddMatchingRelationsFor(DonorInfoWithExpandedHla donor)
+        {
+            var hlaLookup = await hlaImportRepository.ImportHla(new List<DonorInfoWithExpandedHla> {donor});
+            var donorEntry = donor.ToDonorInfoForPreProcessing(hla => hlaLookup[hla]);
+
+            await donorImportRepository.AddMatchingRelationsForExistingDonorBatch(
+                new List<DonorInfoForHlaPreProcessing> {donorEntry},
+                false);
+        }
+
+        #endregion
+
     }
 }

--- a/Atlas.MatchingAlgorithm.Test.Integration/TestHelpers/Repositories/TestDonorInspectionRepository.cs
+++ b/Atlas.MatchingAlgorithm.Test.Integration/TestHelpers/Repositories/TestDonorInspectionRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Atlas.Common.Public.Models.GeneticData;
 using Atlas.MatchingAlgorithm.Data.Repositories.DonorRetrieval;
 using Atlas.MatchingAlgorithm.Data.Services;
 using Atlas.MatchingAlgorithm.Data.Models.Entities;
@@ -24,6 +25,20 @@ namespace Atlas.MatchingAlgorithm.Test.Integration.TestHelpers.Repositories
             using (var conn = new SqlConnection(ConnectionStringProvider.GetConnectionString()))
             {
                 return conn.ExecuteScalar<int>($"SELECT COUNT(*) FROM Donors", commandTimeout: 1);
+            }
+        }
+
+        /// <summary>
+        /// The number of pre-processed matching HLA rows stored for one donor at one locus - one per typed position.
+        /// </summary>
+        public int GetMatchingHlaRowCount(Locus locus, int donorId)
+        {
+            using (var conn = new SqlConnection(ConnectionStringProvider.GetConnectionString()))
+            {
+                return conn.ExecuteScalar<int>(
+                    $"SELECT COUNT(*) FROM {MatchingHla.TableName(locus)} WHERE DonorId = @donorId",
+                    new {donorId},
+                    commandTimeout: 5);
             }
         }
 

--- a/Atlas.MatchingAlgorithm.Test/Repositories/DonorUpdateRepositoryBaseTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Repositories/DonorUpdateRepositoryBaseTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Atlas.Common.ApplicationInsights;
+using Atlas.MatchingAlgorithm.Data.Repositories;
+using Atlas.MatchingAlgorithm.Data.Repositories.DonorUpdates;
+using Atlas.MatchingAlgorithm.Data.Services;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Atlas.MatchingAlgorithm.Test.Repositories;
+
+/// <summary>
+/// Covers what a bulk write session reports when it closes. A session that reused nothing saved nothing, and there are
+/// two supported configurations in which that happens - see DonorUpdateRepositoryBase.OpenBulkWriteSession - so the
+/// trace is the only thing that distinguishes "the optimisation ran" from "the optimisation was inert" in a run's logs.
+/// </summary>
+[TestFixture]
+public class DonorUpdateRepositoryBaseTests
+{
+    private IAtlasLogger logger;
+    private IDonorImportRepository repository;
+
+    [SetUp]
+    public void SetUp()
+    {
+        logger = Substitute.For<IAtlasLogger>();
+        var connectionStringProvider = Substitute.For<IConnectionStringProvider>();
+        connectionStringProvider.GetConnectionString().Returns("Server=not-connected-to;Database=none;");
+
+        repository = new DonorImportRepository(Substitute.For<IHlaNamesRepository>(), connectionStringProvider, logger);
+    }
+
+    [Test]
+    public void OpenBulkWriteSession_WhenClosedHavingReusedNothing_TracesThatNothingWasReused()
+    {
+        // No write is made, so nothing is reused. A bulk copy opens no connection until its first write, so this
+        // reaches no database despite the connection string being unusable.
+        repository.OpenBulkWriteSession().Dispose();
+
+        logger.Received(1).SendTrace(
+            Arg.Is<string>(m => m.Contains("without reusing any bulk copy")),
+            Arg.Any<LogLevel>(),
+            Arg.Is<Dictionary<string, string>>(p => p["ReusedWrites"] == "0"));
+    }
+
+    [Test]
+    public void OpenBulkWriteSession_WhenDisposedTwice_ReportsOnce()
+    {
+        var session = repository.OpenBulkWriteSession();
+
+        session.Dispose();
+        session.Dispose();
+
+        logger.ReceivedWithAnyArgs(1).SendTrace(default, default, default);
+    }
+}

--- a/Atlas.MatchingAlgorithm.Test/Services/DataRefresh/DonorImporterTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Services/DataRefresh/DonorImporterTests.cs
@@ -83,6 +83,23 @@ namespace Atlas.MatchingAlgorithm.Test.Services.DataRefresh
         }
 
         [Test]
+        public async Task ImportDonors_OpensOneBulkWriteSessionForTheWholeStage()
+        {
+            var session = Substitute.For<IDisposable>();
+            donorImportRepository.OpenBulkWriteSession().Returns(session);
+            donorReader.StreamAllDonors().Returns(new List<Donor>
+            {
+                DonorBuilder.New.With(d => d.AtlasDonorId, 1).Build(),
+                DonorBuilder.New.With(d => d.AtlasDonorId, 2).Build()
+            });
+
+            await donorImporter.ImportDonors();
+
+            donorImportRepository.Received(1).OpenBulkWriteSession();
+            session.Received(1).Dispose();
+        }
+
+        [Test]
         public async Task ImportDonors_ConvertsDonorInfo()
         {
             var donor = DonorBuilder.New.With(d => d.AtlasDonorId, 123).Build();

--- a/Atlas.MatchingAlgorithm.Test/Services/DataRefresh/HlaProcessorTests.cs
+++ b/Atlas.MatchingAlgorithm.Test/Services/DataRefresh/HlaProcessorTests.cs
@@ -298,6 +298,38 @@ namespace Atlas.MatchingAlgorithm.Test.Services.DataRefresh
                 Arg.Any<string>(), Arg.Is<LogLevel>(level => level >= LogLevel.Error), Arg.Any<Dictionary<string, string>>());
         }
 
+        [Test]
+        public async Task UpdateDonorHla_OpensOneBulkWriteSessionForTheWholeStage()
+        {
+            var session = Substitute.For<IDisposable>();
+            donorImportRepository.OpenBulkWriteSession().Returns(session);
+            GivenDonorBatches(4);
+
+            await hlaProcessor.UpdateDonorHla(HlaNomenclatureVersion, _ => Task.CompletedTask);
+
+            donorImportRepository.Received(1).OpenBulkWriteSession();
+            session.Received(1).Dispose();
+        }
+
+        [Test]
+        public async Task UpdateDonorHla_WhenCancelledMidProcessing_StillClosesTheBulkWriteSession()
+        {
+            // The session holds a connection per matching HLA table open for as long as it is open, so an abort that
+            // left it undisposed would leak them for the lifetime of the process.
+            var session = Substitute.For<IDisposable>();
+            donorImportRepository.OpenBulkWriteSession().Returns(session);
+            var cancellationTokenSource = new CancellationTokenSource();
+            GivenDonorBatches(4);
+            donorImportRepository.WhenForAnyArgs(r => r.AddMatchingRelationsForExistingDonorBatch(default, default, default))
+                .Do(_ => cancellationTokenSource.Cancel());
+
+            await hlaProcessor.Invoking(p => p.UpdateDonorHla(
+                    HlaNomenclatureVersion, _ => Task.CompletedTask, null, false, cancellationTokenSource.Token))
+                .Should().ThrowAsync<OperationCanceledException>();
+
+            session.Received(1).Dispose();
+        }
+
         /// <summary>
         /// Throws on the given page, so a read-side failure lands partway through the stream rather than at its start.
         /// </summary>

--- a/Atlas.MatchingAlgorithm/Services/DataRefresh/DonorImport/DonorImporter.cs
+++ b/Atlas.MatchingAlgorithm/Services/DataRefresh/DonorImport/DonorImporter.cs
@@ -94,7 +94,16 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh.DonorImport
         {
             try
             {
-                var allFailedDonors = await RunImportPipeline(shouldMarkDonorsAsUpdated, cancellationToken);
+                List<FailedDonorInfo> allFailedDonors;
+
+                // One session for the whole stage, not one per batch - see IDonorImportRepository.OpenBulkWriteSession.
+                // Wraps the whole pipeline rather than the write side alone: every write happens on the pipeline's
+                // processing side, so this still opens and closes exactly once per stage, and the using still closes it
+                // when the stage is cancelled or fails.
+                using (matchingDonorImportRepository.OpenBulkWriteSession())
+                {
+                    allFailedDonors = await RunImportPipeline(shouldMarkDonorsAsUpdated, cancellationToken);
+                }
 
                 await failedDonorsNotificationSender.SendFailedDonorsAlert(allFailedDonors, ImportFailureEventName, Priority.Medium);
                 logger.SendTrace("Donor import is complete");

--- a/Atlas.MatchingAlgorithm/Services/DataRefresh/HlaProcessing/HlaProcessor.cs
+++ b/Atlas.MatchingAlgorithm/Services/DataRefresh/HlaProcessing/HlaProcessor.cs
@@ -198,6 +198,10 @@ namespace Atlas.MatchingAlgorithm.Services.DataRefresh.HlaProcessing
             using (timerCollection.InitialiseStopwatch(DataRefreshTimingKeys.HlaUpsert_BlockingWait_TimerKey, " * * Time spent in `Task.WhenAll`, JUST waiting on HlaInsert tasks to Complete, during HlaProcessing") )
             using (timerCollection.InitialiseStopwatch(DataRefreshTimingKeys.HlaUpsert_DtWriteExecution_TimerKey, " * * * Total Time spent across all threads, writing BulkInserts during HlaInsert operation, during HlaProcessing", null, summaryReportWithThreadingCount))
                 // @formatter:on
+            // One session for the whole stage, not one per batch - see IDonorImportRepository.OpenBulkWriteSession.
+            // Wraps the whole pipeline rather than the processing side alone: every write happens on that side, so the
+            // session is still opened and closed exactly once, and is never touched by the concurrent read side.
+            using (donorImportRepository.OpenBulkWriteSession())
             {
                 failedDonors.AddRange(await RunHlaProcessingPipeline(
                     batchedDonors, hlaNomenclatureVersion, updateLastSafelyProcessedDonorId, timerCollection, cancellationToken));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1525)
<!-- Reviewable:end -->
