### PR TITLE
feature: ATL-290: add Atlas team action group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 [Oo]bj/
 [Ll]og/
 
+# macOS
+.DS_Store
+
+# Local temp directory
+/temp/
+
 # Generated Reqnroll feature code-behind
 *.feature.cs
 

--- a/terraform/core/function.tf
+++ b/terraform/core/function.tf
@@ -187,8 +187,8 @@ resource "azurerm_windows_function_app" "atlas_public_api_function" {
   app_settings = {
     "ApplicationInsights:LogLevel" = var.APPLICATION_INSIGHTS_LOG_LEVEL
 
-    "AutoMapper:LicenseKey" = var.AUTOMAPPER_LICENSE_KEY
-    "AtlasFunction:Search:DefaultParallelMatchPrediction" = var.DEFAULT_PARALLEL_MATCH_PREDICTION
+    "AutoMapper:LicenseKey"                                         = var.AUTOMAPPER_LICENSE_KEY
+    "AtlasFunction:Search:DefaultParallelMatchPrediction"           = var.DEFAULT_PARALLEL_MATCH_PREDICTION
     "AtlasFunction:Search:ParallelMatchPredictionRequestPercentage" = var.PARALLEL_MATCH_PREDICTION_REQUEST_PERCENTAGE
 
     "MatchingAlgorithmFunction:BaseUrl" = module.matching_algorithm.function_app.base_url

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -356,6 +356,12 @@ module "search_tracking" {
 module "support" {
   source = "./modules/support"
 
+  general = {
+    environment = local.environment
+    location    = local.location
+    common_tags = local.common_tags
+  }
+
   default_servicebus_settings = local.service-bus
 
   resource_group       = azurerm_resource_group.atlas_resource_group

--- a/terraform/core/modules/support/alerts.tf
+++ b/terraform/core/modules/support/alerts.tf
@@ -1,3 +1,15 @@
+resource "azurerm_monitor_action_group" "atlas_team" {
+  name                = "${var.general.environment}-ATLAS-AG"
+  resource_group_name = var.resource_group.name
+  short_name          = "AtlasAlerts"
+  tags                = var.general.common_tags
+
+  email_receiver {
+    name          = "AtlasTeam"
+    email_address = "atlasteam@anthonynolan.org"
+  }
+}
+
 resource "azurerm_monitor_metric_alert" "service_bus_dead_letter_alert" {
   for_each = var.SUPPORT_DEADLETTER_ALERTS_ACTION_GROUP_ID != null ? var.service_bus_topics_with_alerts : {}
 

--- a/terraform/core/modules/support/outputs.tf
+++ b/terraform/core/modules/support/outputs.tf
@@ -4,5 +4,6 @@ output "general" {
     alerts_servicebus_debug_subscription        = azurerm_servicebus_subscription.debug-alerts.name
     notifications_servicebus_topic              = azurerm_servicebus_topic.notifications
     notifications_servicebus_debug_subscription = azurerm_servicebus_subscription.debug-notifications.name
+    atlas_team_action_group                     = azurerm_monitor_action_group.atlas_team
   }
 }

--- a/terraform/core/modules/support/variables.tf
+++ b/terraform/core/modules/support/variables.tf
@@ -1,3 +1,11 @@
+variable "general" {
+  type = object({
+    environment = string
+    location    = string
+    common_tags = object({})
+  })
+}
+
 variable "default_servicebus_settings" {
   type = object({
     long-expiry                   = string


### PR DESCRIPTION
## Summary
- Adds an `azurerm_monitor_action_group` (per environment) notifying the AtlasTeam Outlook DL (atlasteam@anthonynolan.org), exposed via the support module's `general` output for future cost/monitoring alerting work
- Reformats `function.tf` per `terraform fmt`
- Adds `.DS_Store` and `/temp/` to `.gitignore`

## Test plan
- [x] `terraform validate` passes
- [x] `terraform plan` against `dev` shows only the expected 1-resource addition (the new action group); the remaining 8 planned changes are pre-existing environment drift unrelated to this change
- [ ] Plan against remaining environments (uat, live, wmda-uat, wmda-live) before merge if required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anthony-Nolan/Atlas/1526)
<!-- Reviewable:end -->
